### PR TITLE
Corrigido um bug na implementação do Decimal128

### DIFF
--- a/src/libs/decimal128.extension.ts
+++ b/src/libs/decimal128.extension.ts
@@ -106,7 +106,7 @@ Decimal128.fromNumeric = function toDecimal128(value, decimals = 0) {
 	if (decimals) {
 		let [inteiro, casas] = _value.split('.')
 		casas = casas?.slice(0, decimals)
-		_value = inteiro.concat('.').concat(casas || '')
+		_value = casas ? inteiro.concat('.').concat(casas || '') : inteiro
 	}
 	return Decimal128.fromString(_value)
 }


### PR DESCRIPTION
-- Corrigido um bug na implementação da lib de expansão do Decimal128 onde ao chamar a fromNumeric com um número sem casas decimais passando um valor para 'decimals' causava na string passada para o fromString ter um 'ponto' no final, o que a fazia ser um valor inválido e causava uma exception
-- Fixes #33