### PR TITLE
Implementado fee no sistema de saque

### DIFF
--- a/client/src/routes/balances/_tableRow/index.svelte
+++ b/client/src/routes/balances/_tableRow/index.svelte
@@ -11,6 +11,7 @@
 
 	export let code
 	export let name
+	export let fee
 	export let accounts = []
 
 	let hidden = true
@@ -109,7 +110,7 @@
 			{#if selectedAction === 'deposit'}
 				<DepositCell {name} {accounts} />
 			{:else if selectedAction === 'withdraw'}
-				<WithdrawCell {name} />
+				<WithdrawCell {name} {fee} />
 			{/if}
 		</div>
 	</td>

--- a/client/src/routes/balances/_tableRow/withdrawCell.svelte
+++ b/client/src/routes/balances/_tableRow/withdrawCell.svelte
@@ -3,10 +3,13 @@
 	import * as balances from '../../../stores/balances.js'
 
 	export let name
+	export let fee
 	let withdrawAmount
 
 	/** Impede que o valor digitado do amount seja maior que o saldo disponível */
 	const filterAmount = () => withdrawAmount = withdrawAmount > $balances[name].available ? $balances[name].available : withdrawAmount
+
+	$: amountToReceive = withdrawAmount - fee > 0 ? withdrawAmount - fee : 0
 
 	async function handleWithdraw(event) {
 		const destination = event.target.destination.value
@@ -85,6 +88,10 @@
 	input[type=number] {
 		-moz-appearance:textfield;
 	}
+
+	p {
+		margin: 0
+	}
 </style>
 
 <form on:submit|preventDefault={handleWithdraw}>
@@ -102,6 +109,8 @@
 				on:input="{filterAmount}"
 			>
 		</div>
+		<p>Fee: {fee.toFixed(8)}</p>
+		<p>You will receive: {amountToReceive.toFixed(8)}</p>
 	</div>
 
 	<button type="submit">Withdraw</button>

--- a/client/src/routes/balances/index.svelte
+++ b/client/src/routes/balances/index.svelte
@@ -65,8 +65,8 @@
 		<th>Available Balance</th>
 		<th>Locked Balance</th>
 		<th>Actions</th>
-		{#each currenciesList as {code, name, accounts}}
-			<TableRow {code} {name} {accounts} />
+		{#each currenciesList as {code, name, fee, accounts}}
+			<TableRow {code} {name} {fee} {accounts} />
 		{/each}
 	</table>
 {:catch err}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "unip-tcc",
   "version": "1.0.0",
   "description": "Cryptocurrency exchange webserver",
-  "main": "src/server.js",
+  "main": "src/index.js",
   "scripts": {
     "start": "node build/main_server/index.js",
     "start:nano": "npm start --prefix ./build/external_modules/nano",
@@ -19,7 +19,7 @@
     "build:server": "tsc --build",
     "build:svelte": "npm run export --prefix ./client",
     "build:restruct": "move-cli ./build/src ./build/main_server && move-cli ./public ./build/public",
-    "build:config": "copyfiles -E external_modules/** -e '**/node_modules/**' -e '**/*.js' -e '**/*.ts' build/ && copyfiles -E package* build/main_server/",
+    "build:config": "copyfiles -E external_modules/** -e **/node_modules/** -e **/*.js -e **/*.ts build/ && copyfiles -E package* build/main_server/",
     "build:dep-install": "npm-recursive-install --rootDir=build --production"
   },
   "author": "",

--- a/src/currencyApi/currencies/bitcoin.ts
+++ b/src/currencyApi/currencies/bitcoin.ts
@@ -6,4 +6,5 @@ import Common from './common'
 export class Bitcoin extends Common {
 	name = 'bitcoin' as const
 	code = 'btc' as const
+	fee = 0.001 as const
 }

--- a/src/currencyApi/currencies/common/index.ts
+++ b/src/currencyApi/currencies/common/index.ts
@@ -22,7 +22,7 @@ export default abstract class Common {
 	abstract name: 'bitcoin' | 'nano'
 
 	/** O código da currency */
-	abstract code: string
+	abstract code: 'btc' | 'nano'
 
 	/** A quantidade de casas decimais que esta currency tem */
 	public decimals = 8

--- a/src/currencyApi/currencies/common/index.ts
+++ b/src/currencyApi/currencies/common/index.ts
@@ -24,6 +24,9 @@ export default abstract class Common {
 	/** O código da currency */
 	abstract code: 'btc' | 'nano'
 
+	/** Taxa cobrada do usuário para executar operações de saque */
+	abstract fee: number
+
 	/** A quantidade de casas decimais que esta currency tem */
 	public decimals = 8
 

--- a/src/currencyApi/currencies/nano.ts
+++ b/src/currencyApi/currencies/nano.ts
@@ -6,5 +6,6 @@ import Common from './common'
 export class Nano extends Common {
 	name = 'nano' as const
 	code = 'nano' as const
+	fee = 0.001 as const
 	decimals = 30
 }

--- a/src/currencyApi/index.ts
+++ b/src/currencyApi/index.ts
@@ -128,6 +128,11 @@ export async function withdraw(
 		status: 'preparing'
 	}).save()
 
+	// Desconta o fee do amount
+	const { decimals, fee } = detailsOf(currency)
+	const _amount = amount * Math.pow(10, decimals)
+	const _fee = fee * Math.pow(10, decimals)
+
 	// Adiciona a operação na Transactions
 	const transaction = await new Transaction({
 		_id: opid,
@@ -136,7 +141,7 @@ export async function withdraw(
 		currency,
 		status: 'processing',
 		account,
-		amount: amount - _currencies[currency].fee,
+		amount: (_amount - _fee) / Math.pow(10, decimals),
 		fee: _currencies[currency].fee,
 		timestamp: new Date()
 	}).save()

--- a/src/currencyApi/index.ts
+++ b/src/currencyApi/index.ts
@@ -32,17 +32,27 @@ const _currencies = {
 export const currencies = Object.values(_currencies).map(currency => currency.name)
 
 /**
- * Um array de objetos com informações detalhadas sobre as currencies
- * suportadas pela api
- *
- * O objeto contém as propriedades 'name', 'code' e 'decimals'
- *
- * @todo Isso não ser um array
+ * Retorna informações detalhada sobre uma currency suportada pela API
  */
-export const currenciesDetailed = Object.values(_currencies).map(currency => {
-	const { name, code, supportedDecimals } = currency
-	return { name, code, decimals: supportedDecimals }
-})
+export const detailsOf = (function() {
+	const detailsMap = new Map<SuportedCurrencies, {
+		code: Common['code']
+		decimals: Common['supportedDecimals']
+	}>()
+
+	for (const currency of currencies) {
+		detailsMap.set(currency, {
+			code: _currencies[currency].code,
+			decimals: _currencies[currency].supportedDecimals,
+		})
+	}
+
+	return function currenciesDetailed(currency: SuportedCurrencies) {
+		const details = detailsMap.get(currency)
+		if (!details) throw new Error(`The currency '${currency}' was not found`)
+		return details
+	}
+})()
 
 /** EventEmmiter para eventos internos */
 // const _events = new EventEmitter()

--- a/src/currencyApi/index.ts
+++ b/src/currencyApi/index.ts
@@ -136,7 +136,8 @@ export async function withdraw(
 		currency,
 		status: 'processing',
 		account,
-		amount,
+		amount: amount - _currencies[currency].fee,
+		fee: _currencies[currency].fee,
 		timestamp: new Date()
 	}).save()
 

--- a/src/currencyApi/index.ts
+++ b/src/currencyApi/index.ts
@@ -32,18 +32,20 @@ const _currencies = {
 export const currencies = Object.values(_currencies).map(currency => currency.name)
 
 /**
- * Retorna informações detalhada sobre uma currency suportada pela API
+ * Retorna informações detalhadas sobre uma currency suportada pela API
  */
 export const detailsOf = (function() {
 	const detailsMap = new Map<SuportedCurrencies, {
 		code: Common['code']
 		decimals: Common['supportedDecimals']
+		fee: Common['fee']
 	}>()
 
 	for (const currency of currencies) {
 		detailsMap.set(currency, {
 			code: _currencies[currency].code,
 			decimals: _currencies[currency].supportedDecimals,
+			fee: _currencies[currency].fee
 		})
 	}
 

--- a/src/db/models/transaction.ts
+++ b/src/db/models/transaction.ts
@@ -165,6 +165,8 @@ interface TransactionDoc extends Document {
 	account: TransactionInternal['account']
 	/** Amount da transação */
 	amount: Decimal128
+	/** Taxa cobrada para a execução da operação */
+	fee: number
 	/** Tipo dessa transação */
 	type: TransactionInternal['type']
 	/**
@@ -215,6 +217,11 @@ const TransactionSchema: Schema = new Schema({
 	amount: {
 		type: Decimal128,
 		required: true
+	},
+	fee: {
+		type: Number,
+		min: 0,
+		default: 0
 	},
 	timestamp: {
 		type: Date,

--- a/src/userApi/user.ts
+++ b/src/userApi/user.ts
@@ -1,24 +1,9 @@
 import { sha512 } from 'js-sha512'
 import { ObjectId, Decimal128 } from 'mongodb'
-import * as currencyApi from '../currencyApi'
-import { Pending } from '../db/models/person/currencies/pending'
+import * as CurrencyApi from '../currencyApi'
+import type { Pending } from '../db/models/person/currencies/pending'
 import type { Person } from '../db/models/person'
 import type { SuportedCurrencies as SC } from '../currencyApi'
-
-/**
- * Um map com as casas decimais de cada uma das currencies suportadas
- */
-const decimals = new Map<SC, number>()
-
-/**
- * Acessa a CurrencyApi no próximo tick para garantir que ela estará
- * completamente carregada (UserApi e CurrencyApi tem dependência circular)
- */
-setImmediate(() => {
-	currencyApi.currenciesDetailed.forEach(currency => {
-		decimals.set(currency.name, currency.decimals)
-	})
-})
 
 /**
  * Interface utilizada pela balanceOps para operações de manipulação de saldo
@@ -139,7 +124,7 @@ export default class User {
 			const pending: Pending = {
 				opid: op.opid,
 				type: op.type,
-				amount: Decimal128.fromNumeric(op.amount, decimals.get(currency))
+				amount: Decimal128.fromNumeric(op.amount, CurrencyApi.detailsOf(currency).decimals)
 			}
 
 			const response = await this.person.collection.findOneAndUpdate({

--- a/src/websocket/router/balances.ts
+++ b/src/websocket/router/balances.ts
@@ -5,6 +5,7 @@ import User from '../../userApi/user'
 export interface List {
 	name: CurrencyApi.SuportedCurrencies
 	code: ReturnType<typeof CurrencyApi['detailsOf']>['code']
+	fee: ReturnType<typeof CurrencyApi['detailsOf']>['fee']
 	decimals: ReturnType<typeof CurrencyApi['detailsOf']>['decimals']
 	accounts: ReturnType<User['getAccounts']>|undefined
 }
@@ -35,6 +36,7 @@ export default function balances(socket: SocketIO.Socket) {
 			list.push({
 				name:     currency,
 				code:     details.code,
+				fee:      details.fee,
 				decimals: details.decimals,
 				accounts: socket.user?.getAccounts(currency)
 			})

--- a/src/websocket/router/balances.ts
+++ b/src/websocket/router/balances.ts
@@ -3,9 +3,9 @@ import User from '../../userApi/user'
 
 /** Interface do retorno do socket ao receber 'list' */
 export interface List {
-	code: typeof CurrencyApi['currenciesDetailed'][number]['code']
-	name: typeof CurrencyApi['currenciesDetailed'][number]['name']
-	decimals: typeof CurrencyApi['currenciesDetailed'][number]['decimals']
+	name: CurrencyApi.SuportedCurrencies
+	code: ReturnType<typeof CurrencyApi['detailsOf']>['code']
+	decimals: ReturnType<typeof CurrencyApi['detailsOf']>['decimals']
 	accounts: ReturnType<User['getAccounts']>|undefined
 }
 
@@ -29,12 +29,17 @@ export default function balances(socket: SocketIO.Socket) {
 		if (!socket.user) return callback('NotLoggedIn')
 
 		console.log('requested list')
-		const list = CurrencyApi.currenciesDetailed.map(currency => ({
-			code:     currency.code,
-			name:     currency.name,
-			decimals: currency.decimals,
-			accounts: socket.user?.getAccounts(currency.name),
-		}))
+		const list: List[] = []
+		for (const currency of CurrencyApi.currencies) {
+			const details = CurrencyApi.detailsOf(currency)
+			list.push({
+				name:     currency,
+				code:     details.code,
+				decimals: details.decimals,
+				accounts: socket.user?.getAccounts(currency)
+			})
+		}
+
 		callback(null, list)
 	})
 

--- a/tests/CurrencyApi/operations.test.ts
+++ b/tests/CurrencyApi/operations.test.ts
@@ -1,0 +1,82 @@
+import '../../src/libs'
+import { expect } from 'chai'
+import { Decimal128, ObjectId } from 'mongodb'
+import Person from '../../src/db/models/person'
+import Checklist from '../../src/db/models/checklist'
+import Transaction from '../../src/db/models/transaction'
+import * as CurrencyApi from '../../src/currencyApi'
+import * as UserApi from '../../src/userApi'
+import type User from '../../src/userApi/user'
+
+describe('Testing operations on the currencyApi', () => {
+	let user: User
+
+	before(async () => {
+		await Person.deleteMany({})
+		await Checklist.deleteMany({})
+
+		user = await UserApi.createUser('operations@example.com', 'userP@ss')
+
+		// Manualmente seta o saldo disponível para 1
+		for (const currency of CurrencyApi.currencies) {
+			user.person.currencies[currency].balance.available = Decimal128.fromNumeric(1)
+		}
+		await user.person.save()
+	})
+
+	describe('Testing withdraw', () => {
+		let opid: ObjectId
+		const amount = 0.011
+
+		for (const currency of CurrencyApi.currencies) {
+			const account = `operations-${currency}`
+
+			before(async () => {
+				opid = await CurrencyApi.withdraw(user, currency, account, amount)
+				expect(opid).to.be.an('object')
+				expect(opid).to.be.instanceOf(ObjectId)
+			})
+
+			it('Should have saved the transaction', async () => {
+				const tx = await Transaction.findById(opid)
+				expect(tx).to.be.an('object')
+			})
+
+			it('Should have a valid fee', async () => {
+				const tx = await Transaction.findById(opid)
+				expect(tx.fee).to.be.a('number').and.greaterThan(0)
+			})
+
+			it('Should have saved the transaction with the correct amount', async () => {
+				const tx = await Transaction.findById(opid)
+
+				// Checa se o fee foi descontado
+				expect(+tx.amount.toFullString()).to.be.lessThan(amount)
+				expect(+tx.amount.toFullString() + tx.fee).to.equal(amount)
+
+				// Checa se houve erro de arredondamento convertendo pra string
+				expect(+tx.amount.toFullString())
+					.to.equal(+(amount - tx.fee)
+						.toFixed(CurrencyApi.detailsOf(currency).decimals))
+
+				/*
+				 * Checa se houve erros de arredondamento comparando as
+				 * as casas decimais significativas
+				 */
+				const amount_decimals = tx.amount.toFullString().split('.')[1].length
+				const fee_decimals = tx.fee.toString().split('.')[1].length
+				const tst_amount_decimals = amount.toString().split('.')[1].length
+				expect(Math.max(amount_decimals, fee_decimals)).to.equal(tst_amount_decimals)
+
+				/*
+				 * Checa se houve erros no arredondamento somando os valores
+				 */
+				const expoencial = 10 * CurrencyApi.detailsOf(currency).decimals
+				const _tx_amount = Math.trunc(+tx.amount.toFullString() * expoencial)
+				const _fee = Math.trunc(tx.fee * expoencial)
+				const _tst_amount = Math.trunc(amount * expoencial)
+				expect(_tx_amount + _fee).to.equal(_tst_amount)
+			})
+		}
+	})
+})

--- a/tests/CurrencyApi/receiving-requests.test.ts
+++ b/tests/CurrencyApi/receiving-requests.test.ts
@@ -206,9 +206,7 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 							expect(doc.amount.toFullString()).to.equals(
 								Decimal128.fromNumeric(
 									transaction.amount,
-									CurrencyApi.currenciesDetailed
-										.find(c => c.name === currency)
-										.decimals
+									CurrencyApi.detailsOf(currency).decimals
 								).toFullString()
 							)
 							done()

--- a/tests/CurrencyApi/receiving-requests.test.ts
+++ b/tests/CurrencyApi/receiving-requests.test.ts
@@ -1,7 +1,6 @@
 import '../../src/libs'
 import io from 'socket.io-client'
 import { expect } from 'chai'
-import { callbackify } from 'util'
 import { Decimal128, ObjectId } from 'mongodb'
 import Person from '../../src/db/models/person'
 import Checklist from '../../src/db/models/checklist'
@@ -16,6 +15,7 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 
 	before(async () => {
 		await Person.deleteMany({})
+		await Transaction.deleteMany({})
 
 		user = await UserApi.createUser('receival_test@example.com', 'userP@ss')
 		await Checklist.deleteMany({})
@@ -30,84 +30,95 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 		}
 	})
 
-	afterEach(done => {
-		// Garante que a CurrencyApi terminou de processar o request
-		setTimeout(done, 50)
-	})
-
 	for (const currency of CurrencyApi.currencies) {
-		describe(currency, () => {
-			let client: SocketIOClient.Socket
+		const CURRENCY_API_PORT = process.env.CURRENCY_API_PORT || 5808
+		let client: SocketIOClient.Socket
+		let account_counter = 0
+		let txid: string
+		let txidCounter = 0
 
-			before(() => {
-				client = io(`http://127.0.0.1:${process.env.CURRENCY_API_PORT}/${currency}`)
+		before(() => {
+			client = io(`http://127.0.0.1:${CURRENCY_API_PORT}/${currency}`)
+
+			// Responde eventos de create_account para evitar timeout
+			client.on('create_new_account', async (callback: (err: any, account: string) => void) => {
+				account_counter++
+				callback(null, 'account-' + currency + account_counter)
 			})
+		})
 
-			after(() => {
-				client.disconnect()
-			})
+		beforeEach(() => {
+			txidCounter++
+			txid = `txid-${currency}-${txidCounter}`
+		})
 
-			describe('When receiving new_transaction', () => {
-				beforeEach(async () => {
-					await Transaction.deleteMany({})
-					await Person.findByIdAndUpdate(user.id, {
-						$set: {
-							[`currencies.${currency}.balance.available`]: Decimal128.fromNumeric(0),
-							[`currencies.${currency}.balance.locked`]: Decimal128.fromNumeric(0)
-						}
-					})
-				})
+		after(() => {
+			client.disconnect()
+		})
 
-				it('Should fail if user was not found', done => {
-					const transaction: TxReceived = {
-						txid: 'randomTxid',
-						status: 'pending',
-						amount: 10,
-						account: 'not-existing-account',
-						timestamp: 123456789
+		describe(`When ${currency} module receives new_transaction`, () => {
+			beforeEach(async () => {
+				await Person.findByIdAndUpdate(user.id, {
+					$set: {
+						[`currencies.${currency}.balance.available`]: Decimal128.fromNumeric(0),
+						[`currencies.${currency}.balance.locked`]: Decimal128.fromNumeric(0)
 					}
+				})
+			})
 
+			it('Should fail if user was not found', done => {
+				const transaction: TxReceived = {
+					txid,
+					status: 'pending',
+					amount: 10,
+					account: 'not-existing-account',
+					timestamp: 123456789
+				}
+
+				Transaction.find({}, (err, txs_before) => {
 					client.emit('new_transaction', transaction, (err: any, response?: any) => {
 						expect(err).to.haveOwnProperty('code').equals('UserNotFound')
 						expect(response).to.be.undefined
 						Transaction.find({}, (err, transactions) => {
-							expect(transactions).to.be.empty
+							expect(transactions.length).to.equals(txs_before.length)
 							done()
 						})
 					})
 				})
+			})
 
-				it('Should save the transaction on the Transactions collection', done => {
-					const transaction: TxReceived = {
-						txid: 'randomTxidSave',
-						status: 'pending',
-						amount: 12.5,
-						account: `${currency}-account`,
-						timestamp: 123456789
-					}
+			it('Should save the transaction on the Transactions collection', done => {
+				const transaction: TxReceived = {
+					txid,
+					status: 'pending',
+					amount: 12.5,
+					account: `${currency}-account`,
+					timestamp: 123456789
+				}
 
-					client.emit('new_transaction', transaction, (err: any, opid?: any) => {
-						expect(err).to.be.null
-						expect(opid).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.user.toHexString()).to.equals(user.id.toHexString())
-							expect(doc.txid).to.equals(transaction.txid)
-							expect(doc.status).to.equals(transaction.status)
-							expect(doc.amount.toFullString()).to.equals(transaction.amount.toString())
-							done()
-						})
-					})
+				client.emit('new_transaction', transaction, (err: any, opid?: string) => {
+					expect(err).to.be.null
+					expect(opid).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.user.toHexString()).to.equals(user.id.toHexString())
+						expect(doc.txid).to.equals(transaction.txid)
+						expect(doc.status).to.equals(transaction.status)
+						expect(doc.amount.toFullString()).to.equals(transaction.amount.toString())
+						done()
+					}).catch(done)
 				})
+			})
 
-				it('Should add locked balance for pending transactions', done => {
-					const transaction: TxReceived = {
-						txid: 'randomTxidLocked',
-						status: 'pending',
-						amount: 49.7,
-						account: `${currency}-account`,
-						timestamp: 123456789
-					}
+			it('Should add locked balance for pending transactions', done => {
+				const transaction: TxReceived = {
+					txid,
+					status: 'pending',
+					amount: 49.7,
+					account: `${currency}-account`,
+					timestamp: 123456789
+				}
 
+				setImmediate(async () => {
 					client.emit('new_transaction', transaction, () => {
 						Person.findById(user.id, (err, doc) => {
 							expect(doc.currencies[currency].balance.available.toFullString())
@@ -118,523 +129,291 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 						})
 					})
 				})
+			})
 
-				it('Should add available balance for confirmed transactions', done => {
-					const transaction: TxReceived = {
-						txid: 'randomTxidAvailable',
-						status: 'confirmed',
-						amount: 4.79,
-						account: `${currency}-account`,
-						timestamp: 123456789
-					}
+			it('Should add available balance for confirmed transactions', done => {
+				const transaction: TxReceived = {
+					txid,
+					status: 'confirmed',
+					amount: 4.79,
+					account: `${currency}-account`,
+					timestamp: 123456789
+				}
 
-					client.emit('new_transaction', transaction, () => {
-						Person.findById(user.id, (err, doc) => {
-							expect(doc.currencies[currency].balance.available.toFullString())
-								.to.equals(transaction.amount.toString())
-							expect(doc.currencies[currency].balance.locked.toFullString())
-								.to.equals('0.0')
-							done()
-						})
-					})
+				client.emit('new_transaction', transaction, async () => {
+					const doc = await Person.findById(user.id)
+					expect(doc.currencies[currency].balance.available.toFullString())
+						.to.equals(transaction.amount.toString())
+					expect(doc.currencies[currency].balance.locked.toFullString())
+						.to.equals('0.0')
+					done()
+				})
+			})
+
+			it('Should emit the new_transaction event', done => {
+				const transaction: TxReceived = {
+					txid,
+					status: 'pending',
+					amount: 24.93,
+					account: `${currency}-account`,
+					timestamp: 123456789
+				}
+
+				CurrencyApi.events.once('new_transaction', (id, coin, tx) => {
+					expect(id.toHexString()).to.equals(user.id.toHexString())
+					expect(coin).to.equals(currency)
+					expect(tx).to.be.an('object')
+					expect(tx.txid).to.equals(transaction.txid)
+					expect(tx.status).to.equals(transaction.status)
+					expect(tx.amount.toString()).to.equals(transaction.amount.toString())
+					expect(tx.currency).to.equals(currency)
+					expect(tx.account).to.equals(transaction.account)
+					expect(tx.timestamp).to.be.a('Date')
+					done()
 				})
 
-				it('Should emit the new_transaction event', done => {
-					const transaction: TxReceived = {
-						txid: 'randomTxidEvent',
-						status: 'pending',
-						amount: 24.93,
-						account: `${currency}-account`,
-						timestamp: 123456789
-					}
+				// eslint-disable-next-line @typescript-eslint/no-empty-function
+				client.emit('new_transaction', transaction, () => {})
+			})
 
-					CurrencyApi.events.once('new_transaction', (id, coin, tx) => {
-						expect(id.toHexString()).to.equals(user.id.toHexString())
-						expect(coin).to.equals(currency)
-						expect(tx).to.be.an('object')
-						expect(tx.txid).to.equals(transaction.txid)
-						expect(tx.status).to.equals(transaction.status)
-						expect(tx.amount.toString()).to.equals(transaction.amount.toString())
-						expect(tx.currency).to.equals(currency)
-						expect(tx.account).to.equals(transaction.account)
-						expect(tx.timestamp).to.be.a('Date')
+			it('Should return the transaction if it already exists', done => {
+				const transaction: TxReceived = {
+					txid,
+					status: 'pending',
+					amount: 49.379547,
+					account: `${currency}-account`,
+					timestamp: 123456789
+				}
+
+				client.emit('new_transaction', transaction, (err: any, opid?: string) => {
+					expect(err).to.be.null
+					expect(opid).to.be.a('string')
+					client.emit('new_transaction', transaction, (err: any, _opid?: string) => {
+						expect(_opid).to.be.undefined
+						expect(err).to.be.an('object')
+						expect(err.code).to.equals('TransactionExists')
+						expect(err.transaction).to.be.an('object')
+						expect(err.transaction.opid).to.equals(opid)
+						expect(err.transaction.txid).to.equals(transaction.txid)
+						expect(err.transaction.status).to.equals(transaction.status)
+						expect(err.transaction.amount).to.equals(transaction.amount.toString())
+						expect(err.transaction.account).to.equals(transaction.account)
 						done()
 					})
-
-					// eslint-disable-next-line @typescript-eslint/no-empty-function
-					client.emit('new_transaction', transaction, () => {})
 				})
+			})
 
-				it('Should return the transaction if it already exists', done => {
-					const transaction: TxReceived = {
-						txid: 'randomTxidDuplicated',
-						status: 'pending',
-						amount: 49.379547,
-						account: `${currency}-account`,
-						timestamp: 123456789
+			it('Sould ignore digits after supported when saving the transaction', done => {
+				const transaction: TxReceived = {
+					txid,
+					status: 'pending',
+					amount: 1.23456789101112131415,
+					account: `${currency}-account`,
+					timestamp: 123456789
+				}
+
+				client.emit('new_transaction', transaction, (err: any, opid?: string) => {
+					Transaction.findById(opid).then(doc => {
+						expect(doc.amount.toFullString()).to.equals(
+							Decimal128.fromNumeric(
+								transaction.amount,
+								CurrencyApi.detailsOf(currency).decimals
+							).toFullString()
+						)
+						done()
+					}).catch(done)
+				})
+			})
+
+			describe('And sending invalid data', () => {
+				const transaction: TxReceived = {
+					txid,
+					status: 'pending',
+					amount: 10.9,
+					account: `${currency}-account`,
+					timestamp: 123456789
+				}
+
+				it('Should fail if amount is a negative value', done => {
+					const negativeAmount: TxReceived = {
+						...transaction,
+						amount: -49.37954
 					}
 
-					client.emit('new_transaction', transaction, (err: any, opid?: string) => {
-						expect(err).to.be.null
-						expect(opid).to.be.a('string')
-						client.emit('new_transaction', transaction, (err: any, _opid?: string) => {
-							expect(_opid).to.be.undefined
-							expect(err).to.be.an('object')
-							expect(err.code).to.equals('TransactionExists')
-							expect(err.transaction).to.be.an('object')
-							expect(err.transaction.opid).to.equals(opid)
-							expect(err.transaction.txid).to.equals(transaction.txid)
-							expect(err.transaction.status).to.equals(transaction.status)
-							expect(err.transaction.amount).to.equals(transaction.amount.toString())
-							expect(err.transaction.account).to.equals(transaction.account)
-							done()
-						})
-					})
-				})
-
-				it('Sould ignore digits after supported when saving the transaction', done => {
-					const transaction: TxReceived = {
-						txid: 'randomTxidDuplicated',
-						status: 'pending',
-						amount: 1.23456789101112131415,
-						account: `${currency}-account`,
-						timestamp: 123456789
-					}
-
-					client.emit('new_transaction', transaction, (err: any, opid?: string) => {
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.amount.toFullString()).to.equals(
-								Decimal128.fromNumeric(
-									transaction.amount,
-									CurrencyApi.detailsOf(currency).decimals
-								).toFullString()
-							)
-							done()
-						})
-					})
-				})
-
-				describe('And sending invalid data', () => {
-					const transaction: TxReceived = {
-						txid: 'randomTxidValidationError',
-						status: 'pending',
-						amount: 10.9,
-						account: `${currency}-account`,
-						timestamp: 123456789
-					}
-
-					it('Should fail if amount is a negative value', done => {
-						const transaction: TxReceived = {
-							txid: 'randomTxidEvent',
-							status: 'pending',
-							amount: -49.37954,
-							account: `${currency}-account`,
-							timestamp: 123456789
-						}
+					setImmediate(async () => {
+						const available = Decimal128.fromNumeric(50).toFullString()
+						const locked = Decimal128.fromNumeric(0).toFullString()
+						const txs_before = await Transaction.find({})
 
 						// Garante que o request não irá falhar por falta de saldo
-						Person.findByIdAndUpdate(user.id, {
+						await Person.findByIdAndUpdate(user.id, {
 							$set: {
-								[`currencies.${currency}.balance.available`]: Decimal128.fromNumeric(50)
+								[`currencies.${currency}.balance.available`]: Decimal128.fromString(available),
+								[`currencies.${currency}.balance.locked`]: Decimal128.fromString(locked)
 							}
-						}, err => {
-							expect(err).to.be.null
-							client.emit('new_transaction', transaction, (err: any, opid?: string) => {
-								expect(err).to.be.an('object')
-								expect(err.code).to.equals('BadRequest')
-								expect(err.message).to.be.a('string')
-								expect(opid).to.be.undefined
-								Person.findById(user.id, (err, doc) => {
-									expect(doc.currencies[currency].balance.available.toFullString())
-										.to.equals('50.0')
-									expect(doc.currencies[currency].balance.locked.toFullString())
-										.to.equals('0.0')
-									Transaction.find({}, (err, txs) => {
-										expect(txs).to.have.lengthOf(0)
-										done()
-									})
-								})
-							})
 						})
-					})
 
-					it('Should return ValidationError if status is invalid', done => {
-						const invalidStatus = {
-							...transaction,
-							status: 'not-valid-status'
-						}
-						client.emit('new_transaction', invalidStatus, (err: any, opid?: string) => {
-							expect(err.code).to.equals('ValidationError')
-							expect(opid).to.be.undefined
-							done()
-						})
-					})
-
-					it('Should return BadRequest if amount is not numeric', done => {
-						const invalidAmount = {
-							...transaction,
-							amount: '68.94p'
-						}
-						client.emit('new_transaction', invalidAmount, (err: any, opid?: string) => {
+						client.emit('new_transaction', negativeAmount, async (err: any, opid?: string) => {
+							expect(err).to.be.an('object')
 							expect(err.code).to.equals('BadRequest')
 							expect(err.message).to.be.a('string')
 							expect(opid).to.be.undefined
+
+							const doc = await Person.findById(user.id)
+							expect(doc.currencies[currency].balance.available.toFullString())
+								.to.equals(available)
+							expect(doc.currencies[currency].balance.locked.toFullString())
+								.to.equals(locked)
+
+							const txs = await Transaction.find({})
+							expect(txs).to.have.lengthOf(txs_before.length)
 							done()
 						})
 					})
+				})
 
-					it('Should return ValidationError if confirmations is not a number', done => {
-						const invalidConfirmations = {
-							...transaction,
-							confirmations: '6j'
-						}
-						client.emit('new_transaction', invalidConfirmations, (err: any, opid?: string) => {
-							console.log('jere')
-							expect(err.code).to.equals('ValidationError')
-							expect(opid).to.be.undefined
-							done()
-						})
+				it('Should return ValidationError if status is invalid', done => {
+					const invalidStatus = {
+						...transaction,
+						status: 'not-valid-status'
+					}
+					client.emit('new_transaction', invalidStatus, (err: any, opid?: string) => {
+						expect(err.code).to.equals('ValidationError')
+						expect(opid).to.be.undefined
+						done()
 					})
+				})
 
-					it('Should return ValidationError if timestamp is not valid', done => {
-						const invalidTimestamp = {
-							...transaction,
-							timestamp: '123456789t'
-						}
-						client.emit('new_transaction', invalidTimestamp, (err: any, opid?: string) => {
-							expect(err.code).to.equals('ValidationError')
-							expect(opid).to.be.undefined
-							done()
-						})
+				it('Should return BadRequest if amount is not numeric', done => {
+					const invalidAmount = {
+						...transaction,
+						amount: '68.94p'
+					}
+					client.emit('new_transaction', invalidAmount, (err: any, opid?: string) => {
+						expect(err.code).to.equals('BadRequest')
+						expect(err.message).to.be.a('string')
+						expect(opid).to.be.undefined
+						done()
+					})
+				})
+
+				it('Should return ValidationError if confirmations is not a number', done => {
+					const invalidConfirmations = {
+						...transaction,
+						confirmations: '6j'
+					}
+					client.emit('new_transaction', invalidConfirmations, (err: any, opid?: string) => {
+						expect(err.code).to.equals('ValidationError')
+						expect(opid).to.be.undefined
+						done()
+					})
+				})
+
+				it('Should return ValidationError if timestamp is not valid', done => {
+					const invalidTimestamp = {
+						...transaction,
+						timestamp: '123456789t'
+					}
+					client.emit('new_transaction', invalidTimestamp, (err: any, opid?: string) => {
+						expect(err.code).to.equals('ValidationError')
+						expect(opid).to.be.undefined
+						done()
 					})
 				})
 			})
+		})
 
-			describe('When receiving update_received_tx', () => {
-				let opid: string
+		describe(`When ${currency} module receives update_received_tx`, () => {
+			const txAmount = Decimal128.fromNumeric(10).toFullString()
+			let opid: string
 
-				beforeEach(done => {
-					Transaction.deleteMany({}).then(() => {
-						return Person.findByIdAndUpdate(user.id, {
-							$set: {
-								[`currencies.${currency}.balance.available`]: Decimal128.fromNumeric(0),
-								[`currencies.${currency}.balance.locked`]: Decimal128.fromNumeric(0)
-							}
-						})
-					}).then(() => {
-						const transaction: TxReceived = {
-							txid: 'randomTxidToUpdate',
-							status: 'pending',
-							amount: 10,
-							account: `${currency}-account`,
-							timestamp: 123456789
-						}
-						client.emit('new_transaction', transaction, (err: any, _opid?: string) => {
-							expect(err).to.be.null
-							expect(_opid).to.be.a('string')
-							opid = _opid
-							setTimeout(done, 50)
-						})
-					})
-				})
-
-				it('Sould update a pending transaction', done => {
-					const updReceived: UpdtReceived = {
-						opid,
+			beforeEach(done => {
+				Person.findByIdAndUpdate(user.id, {
+					$set: {
+						[`currencies.${currency}.balance.available`]: Decimal128.fromNumeric(0),
+						[`currencies.${currency}.balance.locked`]: Decimal128.fromNumeric(0)
+					}
+				}).then(() => {
+					const transaction: TxReceived = {
+						txid,
 						status: 'pending',
-						confirmations: 6
+						amount: txAmount,
+						account: `${currency}-account`,
+						timestamp: 123456789
 					}
-
-					client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
+					client.emit('new_transaction', transaction, (err: any, _opid?: string) => {
 						expect(err).to.be.null
-						expect(res).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.status).to.equals(updReceived.status)
-							expect(doc.confirmations).to.equals(updReceived.confirmations)
-							done()
-						})
+						expect(_opid).to.be.a('string')
+						opid = _opid
+						done()
 					})
-				})
+				}).catch(done)
+			})
 
-				it('Should update a confirmed transaction', done => {
-					const updReceived: UpdtReceived = {
-						opid,
-						status: 'confirmed',
-						confirmations: 6
-					}
+			it('Sould update a pending transaction', done => {
+				const updReceived: UpdtReceived = {
+					opid,
+					status: 'pending',
+					confirmations: 6
+				}
 
-					client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
-						expect(err).to.be.null
-						expect(res).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.status).to.equals(updReceived.status)
-							expect(doc.confirmations).to.be.undefined
-							done()
-						})
-					})
-				})
+				client.emit('update_received_tx', updReceived, async (err: any, res?: string) => {
+					expect(err).to.be.null
+					expect(res).to.be.a('string')
 
-				it('Sould return UserNotFound if a user for existing transaction was not found', done => {
-					// Responde o evento para evitar timeout
-					client.once('create_new_account', (callback: (err: any, account: string) => void) => {
-						callback(null, `account-${currency}-newUser`)
-					})
-
-					callbackify(UserApi.createUser)('randomEmail@email.com', 'UserP@ass', (err, newUser) => {
-						expect(err).to.be.null
-						expect(newUser).to.be.an('object')
-						Person.findByIdAndUpdate(newUser.id, {
-							$push: {
-								[`currencies.${currency}.accounts`]: `${currency}-account-newUser`
-							}
-						}, () => {
-							client.emit('new_transaction', {
-								txid: 'randomTxidOfNewUser',
-								status: 'pending',
-								amount: 10,
-								account: `${currency}-account-newUser`,
-								timestamp: 123456789
-							}, (err: any, opid?: string) => {
-								expect(err).to.be.null
-								expect(opid).to.be.a('string')
-								Person.findByIdAndDelete(newUser.id, () => {
-									client.emit('update_received_tx', {
-										opid,
-										status: 'confirmed',
-										confirmations: 6
-									}, (err: any, res?: string) => {
-										expect(res).to.be.undefined
-										expect(err).to.be.an('object')
-										expect(err.code).to.equals('UserNotFound')
-										expect(err.message).to.be.a('string')
-										done()
-									})
-								})
-							})
-						})
-					})
-				})
-
-				it('Sould not update balance if status is pending', done => {
-					const updReceived: UpdtReceived = {
-						opid,
-						status: 'pending',
-						confirmations: 6
-					}
-
-					client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
-						expect(err).to.be.null
-						expect(res).to.be.a('string')
-						Person.findById(user.id, (err, doc) => {
-							expect(doc.currencies[currency].balance.locked.toFullString())
-								.to.equals('10.0')
-							expect(doc.currencies[currency].balance.available.toFullString())
-								.to.equals('0.0')
-							done()
-						})
-					})
-				})
-
-				it('Should update balance if status is confirmed', done => {
-					const updReceived: UpdtReceived = {
-						opid,
-						status: 'confirmed',
-						confirmations: 6
-					}
-
-					client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
-						expect(err).to.be.null
-						expect(res).to.be.a('string')
-						Person.findById(user.id, (err, doc) => {
-							expect(doc.currencies[currency].balance.locked.toFullString())
-								.to.equals('0.0')
-							expect(doc.currencies[currency].balance.available.toFullString())
-								.to.equals('10.0')
-							done()
-						})
-					})
-				})
-
-				it('Should not fail if confirmations was not informed', done => {
-					const updReceived: UpdtReceived = {
-						opid,
-						status: 'confirmed'
-					}
-
-					client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
-						expect(err).to.be.null
-						expect(res).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.status).to.equals(updReceived.status)
-							expect(doc.confirmations).to.be.undefined
-							done()
-						})
-					})
-				})
-
-				it('Should fail if opid was not informed', done => {
-					client.emit('update_received_tx', {
-						status: 'confirmed',
-						confirmations: 6
-					}, (err: any, res?: string) => {
-						expect(res).to.be.undefined
-						expect(err).to.be.a('object')
-						expect(err.code).to.be.a('string')
-							.that.equals('BadRequest')
-						expect(err.message).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.status).to.equals('pending')
-							done()
-						})
-					})
-				})
-
-				it('Should fail if a valid opid was not found', done => {
-					client.emit('update_received_tx', {
-						opid: '505618b81ce5e89fb0d1b05c',
-						status: 'confirmed',
-						confirmations: 6
-					}, (err: any, res?: string) => {
-						expect(res).to.be.undefined
-						expect(err).to.be.a('object')
-						expect(err.code).to.be.a('string')
-							.that.equals('OperationNotFound')
-						expect(err.message).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.status).to.equals('pending')
-							done()
-						})
-					})
-				})
-
-				it('Should fail if invalid opid was informed', done => {
-					client.emit('update_received_tx', {
-						opid: 'invalid-opid-string',
-						status: 'confirmed',
-						confirmations: 6
-					}, (err: any, res?: string) => {
-						expect(res).to.be.undefined
-						expect(err).to.be.a('object')
-						expect(err.code).to.be.a('string')
-							.that.equals('CastError')
-						expect(err.message).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.status).to.equals('pending')
-							done()
-						})
-					})
-				})
-
-				it('Should fail if status is invalid', done => {
-					client.emit('update_received_tx', {
-						opid,
-						status: 'invalid-status',
-						confirmations: 6
-					}, (err: any, res?: string) => {
-						expect(res).to.be.undefined
-						expect(err).to.be.a('object')
-						expect(err.code).to.be.a('string')
-							.that.equals('ValidationError')
-						expect(err.message).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.status).to.equals('pending')
-							done()
-						})
-					})
+					const doc = await Transaction.findById(opid)
+					expect(doc.status).to.equals(updReceived.status)
+					expect(doc.confirmations).to.equals(updReceived.confirmations)
+					done()
 				})
 			})
 
-			describe('When receiving update_sent_tx', () => {
-				let opid: string
+			it('Should update a confirmed transaction', done => {
+				const updReceived: UpdtReceived = {
+					opid,
+					status: 'confirmed',
+					confirmations: 6
+				}
 
-				beforeEach(done => {
-					Transaction.deleteMany({}).then(() => {
-						return Person.findByIdAndUpdate(user.id, {
-							$set: {
-								[`currencies.${currency}.balance.available`]: Decimal128.fromNumeric(50),
-								[`currencies.${currency}.balance.locked`]: Decimal128.fromNumeric(0)
-							}
-						})
-					}).then(() => {
-						client.once('withdraw', (transaction: TxSend, callback: (err: null, res?: string) => void) => {
-							opid = transaction.opid
-							callback(null, 'received withdraw request for' + opid)
-							setTimeout(done, 50)
-						})
+				client.emit('update_received_tx', updReceived, async (err: any, res?: string) => {
+					expect(err).to.be.null
+					expect(res).to.be.a('string')
 
-						CurrencyApi.withdraw(user, currency, `${currency}_account`, 10)
-							.catch(err => done(err))
+					const doc = await Transaction.findById(opid)
+					expect(doc.status).to.equals(updReceived.status)
+					expect(doc.confirmations).to.be.undefined
+					done()
+				})
+			})
+
+			it('Should return UserNotFound if a user for existing transaction was not found', done => {
+				setImmediate(async () => {
+					// Configura o novo usuário
+					const newUser = await UserApi.createUser(`UserNotFound-receive-${currency}@email.com`, 'UserP@ass')
+					await Person.findByIdAndUpdate(newUser.id, {
+						$push: {
+							[`currencies.${currency}.accounts`]: `${currency}-account-newUser`
+						}
 					})
-				})
 
-				it('Should have status \'processing\' before receiving the first update', async () => {
-					const tx = await Transaction.findById(opid)
-					expect(tx.status).to.equals('processing')
-				})
-
-				it('Sould update a pending transaction', done => {
-					const updSent: UpdtSent = {
-						opid,
-						txid: 'randomTxId',
+					// Emite a transação
+					client.emit('new_transaction', {
+						txid: `UserNotFound-txid-${currency}`,
 						status: 'pending',
-						confirmations: 6,
+						amount: 10,
+						account: `${currency}-account-newUser`,
 						timestamp: 123456789
-					}
-
-					client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
+					}, (err: any, opid?: string) => {
 						expect(err).to.be.null
-						expect(res).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.txid).to.equals(updSent.txid)
-							expect(doc.status).to.equals(updSent.status)
-							expect(doc.confirmations).to.equals(updSent.confirmations)
-							expect(doc.timestamp.toString()).to.equals(new Date(updSent.timestamp).toString())
-							done()
-						})
-					})
-				})
+						expect(opid).to.be.a('string')
 
-				it('Should update a confirmed transaction', done => {
-					const updSent: UpdtSent = {
-						opid,
-						txid: 'randomTxId',
-						status: 'confirmed',
-						confirmations: 6,
-						timestamp: 123456789
-					}
-
-					client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
-						expect(err).to.be.null
-						expect(res).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.txid).to.equals(updSent.txid)
-							expect(doc.status).to.equals(updSent.status)
-							expect(doc.confirmations).to.be.undefined
-							expect(doc.timestamp.toString()).to.equals(new Date(updSent.timestamp).toString())
-							done()
-						})
-					})
-				})
-
-				it('Sould return UserNotFound if a user for existing transaction was not found', done => {
-					let _user: User
-					let _opid: ObjectId
-
-					// Responde os eventos para evitar timeout
-					client.once('create_new_account', (callback: (err: any, account: string) => void) => {
-						callback(null, `account-${currency}-newUser`)
-					})
-
-					client.once('withdraw', (request: TxSend, callback: (err: any, response?: string) => void) => {
-						callback(null, 'received withdraw request for userNotFound test')
-
-						Person.findByIdAndDelete(_user.id, () => {
-							client.emit('update_sent_tx', {
-								opid: _opid,
-								txid: 'randomTxId',
+						// Deleta o novo usuário
+						Person.findByIdAndDelete(newUser.id).then(() => {
+							// Envia um update para a transação do usuário deletado
+							client.emit('update_received_tx', {
+								opid,
 								status: 'confirmed',
-								confirmations: 6,
-								timestamp: 123456789
+								confirmations: 6
 							}, (err: any, res?: string) => {
 								expect(res).to.be.undefined
 								expect(err).to.be.an('object')
@@ -642,165 +421,384 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 								expect(err.message).to.be.a('string')
 								done()
 							})
-						})
-					})
-
-					setImmediate(async () => {
-						_user = await UserApi.createUser('randomEmail@email.com', 'UserP@ass')
-						await Person.findByIdAndUpdate(_user.id, {
-							$set: {
-								[`currencies.${currency}.balance.available`]: Decimal128.fromNumeric(50),
-								[`currencies.${currency}.balance.locked`]: Decimal128.fromNumeric(0)
-							}
-						})
-						_opid = await CurrencyApi.withdraw(_user, currency, 'randomAccount', 10)
+						}).catch(done)
 					})
 				})
+			})
 
-				it('Sould not update balance if status is pending', done => {
-					const updSent: UpdtSent = {
-						opid,
-						txid: 'randomTxId',
-						status: 'pending',
-						confirmations: 6,
-						timestamp: 123456789
+			it('Sould not update balance if status is pending', done => {
+				const updReceived: UpdtReceived = {
+					opid,
+					status: 'pending',
+					confirmations: 6
+				}
+
+				client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
+					expect(err).to.be.null
+					expect(res).to.be.a('string')
+					Person.findById(user.id).then(doc => {
+						expect(doc.currencies[currency].balance.locked.toFullString())
+							.to.equals(txAmount)
+						expect(doc.currencies[currency].balance.available.toFullString())
+							.to.equals('0.0')
+						done()
+					}).catch(done)
+				})
+			})
+
+			it('Should update balance if status is confirmed', done => {
+				const updReceived: UpdtReceived = {
+					opid,
+					status: 'confirmed',
+					confirmations: 6
+				}
+
+				client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
+					expect(err).to.be.null
+					expect(res).to.be.a('string')
+					Person.findById(user.id).then(doc => {
+						expect(doc.currencies[currency].balance.locked.toFullString())
+							.to.equals('0.0')
+						expect(doc.currencies[currency].balance.available.toFullString())
+							.to.equals(txAmount)
+						done()
+					}).catch(done)
+				})
+			})
+
+			it('Should not fail if confirmations was not informed', done => {
+				const updReceived: UpdtReceived = {
+					opid,
+					status: 'confirmed'
+				}
+
+				client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
+					expect(err).to.be.null
+					expect(res).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.status).to.equals(updReceived.status)
+						expect(doc.confirmations).to.be.undefined
+						done()
+					})
+				})
+			})
+
+			it('Should fail if opid was not informed', done => {
+				client.emit('update_received_tx', {
+					status: 'confirmed',
+					confirmations: 6
+				}, (err: any, res?: string) => {
+					expect(res).to.be.undefined
+					expect(err).to.be.a('object')
+					expect(err.code).to.be.a('string')
+						.that.equals('BadRequest')
+					expect(err.message).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.status).to.equals('pending')
+						done()
+					}).catch(done)
+				})
+			})
+
+			it('Should fail if a valid opid was not found', done => {
+				client.emit('update_received_tx', {
+					opid: '505618b81ce5e89fb0d1b05c',
+					status: 'confirmed',
+					confirmations: 6
+				}, (err: any, res?: string) => {
+					expect(res).to.be.undefined
+					expect(err).to.be.a('object')
+					expect(err.code).to.be.a('string')
+						.that.equals('OperationNotFound')
+					expect(err.message).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.status).to.equals('pending')
+						done()
+					}).catch(done)
+				})
+			})
+
+			it('Should fail if invalid opid was informed', done => {
+				client.emit('update_received_tx', {
+					opid: 'invalid-opid-string',
+					status: 'confirmed',
+					confirmations: 6
+				}, (err: any, res?: string) => {
+					expect(res).to.be.undefined
+					expect(err).to.be.a('object')
+					expect(err.code).to.be.a('string')
+						.that.equals('CastError')
+					expect(err.message).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.status).to.equals('pending')
+						done()
+					}).catch(done)
+				})
+			})
+
+			it('Should fail if status is invalid', done => {
+				client.emit('update_received_tx', {
+					opid,
+					status: 'invalid-status',
+					confirmations: 6
+				}, (err: any, res?: string) => {
+					expect(res).to.be.undefined
+					expect(err).to.be.a('object')
+					expect(err.code).to.be.a('string')
+						.that.equals('ValidationError')
+					expect(err.message).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.status).to.equals('pending')
+						done()
+					}).catch(done)
+				})
+			})
+		})
+
+		describe(`When ${currency} module receives update_sent_tx`, () => {
+			let opid: string
+
+			beforeEach(done => {
+				Person.findByIdAndUpdate(user.id, {
+					$set: {
+						[`currencies.${currency}.balance.available`]: Decimal128.fromNumeric(50),
+						[`currencies.${currency}.balance.locked`]: Decimal128.fromNumeric(0)
 					}
+				}).then(() => {
+					client.once('withdraw', (transaction: TxSend, callback: (err: null, res?: string) => void) => {
+						opid = transaction.opid
+						callback(null, 'received withdraw request for' + opid)
+						done()
+					})
+					CurrencyApi.withdraw(user, currency, `${currency}_account`, 10)
+						.catch(done)
+				})
+			})
 
-					client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
-						expect(err).to.be.null
-						expect(res).to.be.a('string')
-						Person.findById(user.id, (err, doc) => {
-							console.log('balances',
-								doc.currencies[currency].balance.locked.toFullString(),
-								doc.currencies[currency].balance.available.toFullString(),
-							)
-							expect(doc.currencies[currency].balance.locked.toFullString())
-								.to.equals('10.0')
-							expect(doc.currencies[currency].balance.available.toFullString())
-								.to.equals('40.0')
+			it('Should have status \'processing\' before receiving the first update', async () => {
+				const tx = await Transaction.findById(opid)
+				expect(tx.status).to.equals('processing')
+			})
+
+			it('Sould update a pending transaction', done => {
+				const updSent: UpdtSent = {
+					opid,
+					txid,
+					status: 'pending',
+					confirmations: 6,
+					timestamp: 123456789
+				}
+
+				client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
+					expect(err).to.be.null
+					expect(res).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.txid).to.equals(updSent.txid)
+						expect(doc.status).to.equals(updSent.status)
+						expect(doc.confirmations).to.equals(updSent.confirmations)
+						expect(doc.timestamp.toString()).to.equals(new Date(updSent.timestamp).toString())
+						done()
+					}).catch(done)
+				})
+			})
+
+			it('Should update a confirmed transaction', done => {
+				const updSent: UpdtSent = {
+					opid,
+					txid,
+					status: 'confirmed',
+					confirmations: 6,
+					timestamp: 123456789
+				}
+
+				client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
+					expect(err).to.be.null
+					expect(res).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.txid).to.equals(updSent.txid)
+						expect(doc.status).to.equals(updSent.status)
+						expect(doc.confirmations).to.be.undefined
+						expect(doc.timestamp.toString()).to.equals(new Date(updSent.timestamp).toString())
+						done()
+					}).catch(done)
+				})
+			})
+
+			it('Should return UserNotFound if a user for existing transaction was not found', done => {
+				let _user: User
+				let _opid: ObjectId
+
+				client.once('withdraw', (request: TxSend, callback: (err: any, response?: string) => void) => {
+					callback(null, 'received withdraw request for userNotFound test')
+
+					Person.findByIdAndDelete(_user.id).then(() => {
+						client.emit('update_sent_tx', {
+							opid: _opid,
+							txid: `randomTxId-deleted-user-${currency}`,
+							status: 'confirmed',
+							confirmations: 6,
+							timestamp: 123456789
+						}, (err: any, res?: string) => {
+							expect(res).to.be.undefined
+							expect(err).to.be.an('object')
+							expect(err.code).to.equals('UserNotFound')
+							expect(err.message).to.be.a('string')
 							done()
 						})
-					})
+					}).catch(done)
 				})
 
-				it('Should update balance if status is confirmed', done => {
-					const updSent: UpdtSent = {
-						opid,
-						txid: 'randomTxId',
-						status: 'confirmed',
-						confirmations: 6,
-						timestamp: 123456789
-					}
-
-					client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
-						expect(err).to.be.null
-						expect(res).to.be.a('string')
-						Person.findById(user.id, (err, doc) => {
-							expect(doc.currencies[currency].balance.locked.toFullString())
-								.to.equals('0.0')
-							expect(doc.currencies[currency].balance.available.toFullString())
-								.to.equals('40.0')
-							done()
-						})
+				setImmediate(async () => {
+					_user = await UserApi.createUser(`non-existing-user-send-${currency}@email.com`, 'UserP@ass')
+					await Person.findByIdAndUpdate(_user.id, {
+						$set: {
+							[`currencies.${currency}.balance.available`]: Decimal128.fromNumeric(50),
+							[`currencies.${currency}.balance.locked`]: Decimal128.fromNumeric(0)
+						}
 					})
+					_opid = await CurrencyApi.withdraw(_user, currency, 'randomAccount', 10)
 				})
+			})
 
-				it('Should not fail if confirmations was not informed', done => {
-					const updSent: UpdtSent = {
-						opid,
-						txid: 'randomTxId',
-						status: 'pending',
-						timestamp: 123456789
-					}
+			it('Sould not update balance if status is pending', done => {
+				const updSent: UpdtSent = {
+					opid,
+					txid,
+					status: 'pending',
+					confirmations: 6,
+					timestamp: 123456789
+				}
 
-					client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
-						expect(err).to.be.null
-						expect(res).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.status).to.equals(updSent.status)
-							expect(doc.confirmations).to.be.undefined
-							done()
-						})
-					})
+				client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
+					expect(err).to.be.null
+					expect(res).to.be.a('string')
+					Person.findById(user.id).then(doc => {
+						expect(doc.currencies[currency].balance.locked.toFullString())
+							.to.equals('10.0')
+						expect(doc.currencies[currency].balance.available.toFullString())
+							.to.equals('40.0')
+						done()
+					}).catch(done)
 				})
+			})
 
-				it('Should fail if opid was not informed', done => {
-					client.emit('update_sent_tx', {
-						txid: 'randomTxId',
-						status: 'confirmed',
-						confirmations: 6,
-						timestamp: 123456789
-					}, (err: any, res?: string) => {
-						expect(res).to.be.undefined
-						expect(err).to.be.a('object')
-						expect(err.code).to.be.a('string')
-							.that.equals('BadRequest')
-						expect(err.message).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.status).to.equals('processing')
-							done()
-						})
-					})
+			it('Should update balance if status is confirmed', done => {
+				const updSent: UpdtSent = {
+					opid,
+					txid,
+					status: 'confirmed',
+					confirmations: 6,
+					timestamp: 123456789
+				}
+
+				client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
+					expect(err).to.be.null
+					expect(res).to.be.a('string')
+					Person.findById(user.id).then(doc => {
+						expect(doc.currencies[currency].balance.locked.toFullString())
+							.to.equals('0.0')
+						expect(doc.currencies[currency].balance.available.toFullString())
+							.to.equals('40.0')
+						done()
+					}).catch(done)
 				})
+			})
 
-				it('Should fail if a valid opid was not found', done => {
-					client.emit('update_sent_tx', {
-						opid: '505618b81ce5e89fb0d1b05c',
-						txid: 'randomTxId',
-						status: 'confirmed',
-						confirmations: 6,
-						timestamp: 123456789
-					}, (err: any, res?: string) => {
-						expect(res).to.be.undefined
-						expect(err).to.be.a('object')
-						expect(err.code).to.be.a('string')
-							.that.equals('OperationNotFound')
-						expect(err.message).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.status).to.equals('processing')
-							done()
-						})
-					})
+			it('Should not fail if confirmations was not informed', done => {
+				const updSent: UpdtSent = {
+					opid,
+					txid,
+					status: 'pending',
+					timestamp: 123456789
+				}
+
+				client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
+					expect(err).to.be.null
+					expect(res).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.status).to.equals(updSent.status)
+						expect(doc.confirmations).to.be.undefined
+						done()
+					}).catch(done)
 				})
+			})
 
-				it('Should fail if invalid opid was informed', done => {
-					client.emit('update_sent_tx', {
-						opid: 'invalid-opid-string',
-						txid: 'randomTxId',
-						status: 'confirmed',
-						confirmations: 6,
-						timestamp: 123456789
-					}, (err: any, res?: string) => {
-						expect(res).to.be.undefined
-						expect(err).to.be.a('object')
-						expect(err.code).to.be.a('string')
-							.that.equals('CastError')
-						expect(err.message).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.status).to.equals('processing')
-							done()
-						})
-					})
+			it('Should fail if opid was not informed', done => {
+				client.emit('update_sent_tx', {
+					txid,
+					status: 'confirmed',
+					confirmations: 6,
+					timestamp: 123456789
+				}, (err: any, res?: string) => {
+					expect(res).to.be.undefined
+					expect(err).to.be.a('object')
+					expect(err.code).to.be.a('string')
+						.that.equals('BadRequest')
+					expect(err.message).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.status).to.equals('processing')
+						done()
+					}).catch(done)
 				})
+			})
 
-				it('Should fail if status is invalid', done => {
-					client.emit('update_sent_tx', {
-						opid,
-						status: 'invalid-status',
-						txid: 'randomTxId',
-						confirmations: 6,
-						timestamp: 123456789
-					}, (err: any, res?: string) => {
-						expect(res).to.be.undefined
-						expect(err).to.be.a('object')
-						expect(err.code).to.be.a('string')
-							.that.equals('ValidationError')
-						expect(err.message).to.be.a('string')
-						Transaction.findById(opid, (err, doc) => {
-							expect(doc.status).to.equals('processing')
-							done()
-						})
-					})
+			it('Should fail if a valid opid was not found', done => {
+				client.emit('update_sent_tx', {
+					opid: '505618b81ce5e89fb0d1b05c',
+					txid,
+					status: 'confirmed',
+					confirmations: 6,
+					timestamp: 123456789
+				}, (err: any, res?: string) => {
+					expect(res).to.be.undefined
+					expect(err).to.be.a('object')
+					expect(err.code).to.be.a('string')
+						.that.equals('OperationNotFound')
+					expect(err.message).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.status).to.equals('processing')
+						done()
+					}).catch(done)
+				})
+			})
+
+			it('Should fail if invalid opid was informed', done => {
+				client.emit('update_sent_tx', {
+					opid: 'invalid-opid-string',
+					txid,
+					status: 'confirmed',
+					confirmations: 6,
+					timestamp: 123456789
+				}, (err: any, res?: string) => {
+					expect(res).to.be.undefined
+					expect(err).to.be.a('object')
+					expect(err.code).to.be.a('string')
+						.that.equals('CastError')
+					expect(err.message).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.status).to.equals('processing')
+						done()
+					}).catch(done)
+				})
+			})
+
+			it('Should fail if status is invalid', done => {
+				client.emit('update_sent_tx', {
+					opid,
+					txid,
+					status: 'invalid-status',
+					confirmations: 6,
+					timestamp: 123456789
+				}, (err: any, res?: string) => {
+					expect(res).to.be.undefined
+					expect(err).to.be.a('object')
+					expect(err.code).to.be.a('string')
+						.that.equals('ValidationError')
+					expect(err.message).to.be.a('string')
+					Transaction.findById(opid).then(doc => {
+						expect(doc.status).to.equals('processing')
+						done()
+					}).catch(done)
 				})
 			})
 		})

--- a/tests/CurrencyApi/sending-requests.test.ts
+++ b/tests/CurrencyApi/sending-requests.test.ts
@@ -56,20 +56,21 @@ describe('Testing if CurrencyApi is making requests to the websocket', () => {
 				})
 
 				it('Should receive a withdraw request', done => {
-					CurrencyApi.withdraw(user, currency, `${currency}_account`, 3.456).then(opid => {
+					const amount = 3.456
+					CurrencyApi.withdraw(user, currency, `${currency}_account`, amount).then(opid => {
 						client = io(url + '/' + currency)
 
 						client.once('withdraw', (request: TxSend, callback: (err: any, response?: string) => void) => {
 							expect(request).to.be.an('object')
 
-							expect(request).to.haveOwnProperty('opid')
-								.that.is.a('string').and.equals(opid.toHexString())
+							expect(request.opid).to.be.a('string')
+								.that.equals(opid.toHexString())
 
-							expect(request).to.haveOwnProperty('account')
-								.that.is.a('string').and.equals(`${currency}_account`)
+							expect(request.account).to.be.a('string')
+								.that.equals(`${currency}_account`)
 
-							expect(request).to.haveOwnProperty('amount')
-								.that.is.a('string').and.equals('3.456')
+							expect(request.amount).to.be.a('string')
+								.that.equals((amount - CurrencyApi.detailsOf(currency).fee).toString())
 
 							callback(null, 'request received for' + currency)
 							done()
@@ -106,6 +107,7 @@ describe('Testing if CurrencyApi is making requests to the websocket', () => {
 				})
 
 				it('Should receive a withdraw request immediate after requested', done => {
+					const amount = 4.567
 					client.once('withdraw', (request: TxSend, callback: (err: any, response?: string) => void) => {
 						expect(request).to.be.an('object')
 
@@ -114,20 +116,19 @@ describe('Testing if CurrencyApi is making requests to the websocket', () => {
 						 * listener de withdraw ser colocado depois do evento
 						 * ser emitido
 						 */
-						expect(request).to.haveOwnProperty('opid')
-							.that.is.a('string')//.and.equals(opid.toHexString())
+						expect(request.opid).to.be.a('string')//.and.equals(opid.toHexString())
 
-						expect(request).to.haveOwnProperty('account')
-							.that.is.a('string').and.equals(`${currency}_account`)
+						expect(request.account).to.be.a('string')
+							.that.equals(`${currency}_account`)
 
-						expect(request).to.haveOwnProperty('amount')
-							.that.is.a('string').and.equals('4.567')
+						expect(request.amount).to.be.a('string')
+							.that.equals((amount - CurrencyApi.detailsOf(currency).fee).toString())
 
 						callback(null, 'request received for' + currency)
 						done()
 					})
 
-					CurrencyApi.withdraw(user, currency, `${currency}_account`, 4.567)
+					CurrencyApi.withdraw(user, currency, `${currency}_account`, amount)
 						.catch(err => done(err))
 				})
 			})

--- a/tests/CurrencyApi/sending-requests.test.ts
+++ b/tests/CurrencyApi/sending-requests.test.ts
@@ -4,19 +4,21 @@ import { expect } from 'chai'
 import { Decimal128 } from 'mongodb'
 import Person from '../../src/db/models/person'
 import Checklist from '../../src/db/models/checklist'
+import Transaction from '../../src/db/models/transaction'
 import * as CurrencyApi from '../../src/currencyApi'
 import * as UserApi from '../../src/userApi'
 import type User from '../../src/userApi/user'
 import type { TxSend } from '../../src/db/models/transaction'
 
 describe('Testing if CurrencyApi is making requests to the websocket', () => {
+	const port = process.env.CURRENCY_API_PORT || 5808
 	let user: User
 
 	before(async () => {
 		await Person.deleteMany({})
-		await Checklist.deleteMany({})
 
 		user = await UserApi.createUser('sending_request@example.com', 'userP@ss')
+		await Checklist.deleteMany({})
 
 		// Manualmente seta o saldo disponível para 10
 		for (const currency of CurrencyApi.currencies) {
@@ -25,113 +27,102 @@ describe('Testing if CurrencyApi is making requests to the websocket', () => {
 		await user.person.save()
 	})
 
-	afterEach(done => {
-		// Garante que a CurrencyApi terminou de processar o request
-		setTimeout(done, 50)
-	})
+	const url = `http://127.0.0.1:${port}`
+	for (const currency of CurrencyApi.currencies) {
+		describe(`Once the ${currency} module connects`, () => {
+			let client: SocketIOClient.Socket
 
-	const url = `http://127.0.0.1:${process.env.CURRENCY_API_PORT}`
-	describe('Once the socket connects', () => {
-		for (const currency of CurrencyApi.currencies) {
-			describe(currency, () => {
-				let client: SocketIOClient.Socket
-
-				before(async () => {
-					await Checklist.deleteMany({})
-				})
-
-				afterEach(() => {
-					client.disconnect()
-				})
-
-				it('Sould receive a create_account request', done => {
-					CurrencyApi.create_accounts(user.id, [currency]).then(() => {
-						client = io(url + '/' + currency)
-
-						client.once('create_new_account', (callback: (err: any, account?: string) => void) => {
-							callback(null, `account-${currency}`)
-							done()
-						})
-					})
-				})
-
-				it('Should receive a withdraw request', done => {
-					const amount = 3.456
-					CurrencyApi.withdraw(user, currency, `${currency}_account`, amount).then(opid => {
-						client = io(url + '/' + currency)
-
-						client.once('withdraw', (request: TxSend, callback: (err: any, response?: string) => void) => {
-							expect(request).to.be.an('object')
-
-							expect(request.opid).to.be.a('string')
-								.that.equals(opid.toHexString())
-
-							expect(request.account).to.be.a('string')
-								.that.equals(`${currency}_account`)
-
-							expect(request.amount).to.be.a('string')
-								.that.equals((amount - CurrencyApi.detailsOf(currency).fee).toString())
-
-							callback(null, 'request received for' + currency)
-							done()
-						})
-					})
-				})
+			afterEach(() => {
+				client.disconnect()
 			})
-		}
-	})
 
-	describe('If the socket is connected', () => {
-		for (const currency of CurrencyApi.currencies) {
-			describe(currency, () => {
-				let client: SocketIOClient.Socket
-
-				before(async () => {
-					await Checklist.deleteMany({})
+			it('Should receive a create_new_account request', done => {
+				CurrencyApi.create_accounts(user.id, [currency]).then(() => {
 					client = io(url + '/' + currency)
-				})
 
-				after(() => {
-					client.disconnect()
-				})
-
-				it('Should receive a create_account request immediate after requested', done => {
 					client.once('create_new_account', (callback: (err: any, account?: string) => void) => {
 						callback(null, `account-${currency}`)
 						done()
 					})
-
-					CurrencyApi.create_accounts(user.id, [currency]).catch(err => {
-						done(err)
-					})
 				})
+			})
 
-				it('Should receive a withdraw request immediate after requested', done => {
-					const amount = 4.567
-					client.once('withdraw', (request: TxSend, callback: (err: any, response?: string) => void) => {
+			it('Should receive a withdraw request', done => {
+				const amount = 3.456
+				CurrencyApi.withdraw(user, currency, `${currency}_account`, amount).then(opid => {
+					client = io(url + '/' + currency)
+
+					client.once('withdraw', async (
+						request: TxSend,
+						callback: (err: any, response?: string) => void
+					) => {
 						expect(request).to.be.an('object')
 
-						/**
-						 * Não dá pra testar o opid porque tem chance de o
-						 * listener de withdraw ser colocado depois do evento
-						 * ser emitido
-						 */
-						expect(request.opid).to.be.a('string')//.and.equals(opid.toHexString())
+						expect(request.opid).to.be.a('string')
+							.that.equals(opid.toHexString())
+
+						const tx = await Transaction.findById(opid)
 
 						expect(request.account).to.be.a('string')
-							.that.equals(`${currency}_account`)
+							.that.equals(tx.account)
 
 						expect(request.amount).to.be.a('string')
-							.that.equals((amount - CurrencyApi.detailsOf(currency).fee).toString())
+							.that.equals(tx.amount.toFullString())
 
 						callback(null, 'request received for' + currency)
 						done()
 					})
-
-					CurrencyApi.withdraw(user, currency, `${currency}_account`, amount)
-						.catch(err => done(err))
 				})
 			})
-		}
-	})
+		})
+
+		describe(`If the ${currency} module is already connected`, () => {
+			let client: SocketIOClient.Socket
+
+			before(async () => {
+				client = io(url + '/' + currency)
+			})
+
+			after(() => {
+				client.disconnect()
+			})
+
+			it('Should receive a create_new_account request immediate after requested', done => {
+				client.once('create_new_account', (callback: (err: any, account?: string) => void) => {
+					callback(null, `account-${currency}`)
+					done()
+				})
+
+				CurrencyApi.create_accounts(user.id, [currency]).catch(err => {
+					done(err)
+				})
+			})
+
+			it('Should receive a withdraw request immediate after requested', done => {
+				const amount = 4.567
+				client.once('withdraw', async (
+					request: TxSend,
+					callback: (err: any, response?: string) => void
+				) => {
+					expect(request).to.be.an('object')
+
+					expect(request.opid).to.be.a('string')
+					const tx = await Transaction.findById(request.opid)
+					expect(tx).to.be.an('object')
+
+					expect(request.account).to.be.a('string')
+						.that.equals(tx.account)
+
+					expect(request.amount).to.be.a('string')
+						.that.equals(tx.amount.toFullString())
+
+					callback(null, 'request received for' + currency)
+					done()
+				})
+
+				CurrencyApi.withdraw(user, currency, `${currency}_account`, amount)
+					.catch(err => done(err))
+			})
+		})
+	}
 })


### PR DESCRIPTION
-- Resolvido um bug no script de compilação que impedia que o código fosse compilado em máquinas linux
-- Reprojetado o array 'currenciesDetailed' da currencyApi na função 'detailsOf', que retorna um objeto com code e decimals
-- Adicionado uma propriedade nas currencies para ser o fee de saque no valor de 0.001 para a nano e bitcoin
-- A função detailsOf agora também retorna o fee de saque de uma currency
-- O evento 'list' do websocket agora retorna o fee como uma das propriedades
-- Adicionado fee na aba da withdraw do site, junto com um campo mostrando o quando o usuário irá receber após o desconto do fee
-- A currencyApi agora desconta o fee de uma transação antes de salvá-la no database
-- A collection das transações agora tem um campo 'fee', que é o valor cobrado de taxa para sua execução