### PR TITLE
Refatorado testes da CurrencyApi

### DIFF
--- a/src/currencyApi/currencies/common/methods/connection.ts
+++ b/src/currencyApi/currencies/common/methods/connection.ts
@@ -87,7 +87,7 @@ export function connection(this: Common, socket: socketIO.Socket) {
 		try {
 			const tx = await new Tx({
 				_id: opid,
-				user: user.id,
+				userId: user.id,
 				txid,
 				type: 'receive',
 				currency: this.name,
@@ -236,13 +236,13 @@ export function connection(this: Common, socket: socketIO.Socket) {
 			await tx.validate()
 
 			if (status === 'confirmed') {
-				const user = await userApi.findUser.byId(tx.user)
+				const user = await userApi.findUser.byId(tx.userId)
 				await user.balanceOps.complete(this.name, new ObjectId(opid))
 			}
 
 			await tx.save()
 			callback(null, `${txUpdate.opid} updated`)
-			this.events.emit('update_received_tx', tx.user, txUpdate)
+			this.events.emit('update_received_tx', tx.userId, txUpdate)
 		} catch (err) {
 			if (err === 'UserNotFound') {
 				callback({

--- a/src/currencyApi/currencies/common/methods/connection.ts
+++ b/src/currencyApi/currencies/common/methods/connection.ts
@@ -1,6 +1,6 @@
 import socketIO from 'socket.io'
 import ss = require('socket.io-stream')
-import { ObjectId, Decimal128 } from 'mongodb'
+import { ObjectId } from 'mongodb'
 import Common from '../index'
 import Person from '../../../../db/models/person'
 import * as userApi from '../../../../userApi'
@@ -54,16 +54,6 @@ export function connection(this: Common, socket: socketIO.Socket) {
 		const { txid, account, amount, status, confirmations } = transaction
 		const timestamp = new Date(transaction.timestamp)
 
-		if (Number.isNaN(+amount)) return callback({
-			code: 'BadRequest',
-			message: 'Amount is not numeric'
-		})
-
-		if (+amount < 0) return callback({
-			code: 'BadRequest',
-			message: 'Amount can not be a negative number'
-		})
-
 		let user: User
 		try {
 			user = await userApi.findUser.byAccount(this.name, account)
@@ -84,19 +74,21 @@ export function connection(this: Common, socket: socketIO.Socket) {
 		 */
 		const opid = new ObjectId()
 
+		const tx = new Tx({
+			_id: opid,
+			userId: user.id,
+			txid,
+			type: 'receive',
+			currency: this.name,
+			status: 'processing',
+			confirmations,
+			account,
+			amount,
+			timestamp
+		})
+
 		try {
-			const tx = await new Tx({
-				_id: opid,
-				userId: user.id,
-				txid,
-				type: 'receive',
-				currency: this.name,
-				status: 'processing',
-				confirmations,
-				account,
-				amount: Decimal128.fromNumeric(amount, this.supportedDecimals),
-				timestamp
-			}).save()
+			await tx.save()
 
 			await user.balanceOps.add(this.name, {
 				opid,
@@ -107,11 +99,6 @@ export function connection(this: Common, socket: socketIO.Socket) {
 			tx.status = status
 			await tx.save()
 
-			/**
-			 * TODO: balanceOp.add ter um argumento opcional
-			 * 'status' = 'pending' | 'complete', que se for o segundo adiciona
-			 * uma operação confirmada
-			 */
 			if (status === 'confirmed')
 				await user.balanceOps.complete(this.name, opid)
 
@@ -180,8 +167,7 @@ export function connection(this: Common, socket: socketIO.Socket) {
 			} else if (err.name === 'ValidationError') {
 				callback({
 					code: 'ValidationError',
-					message: 'Mongoose failed to validate the document',
-					details: err
+					message: err.message
 				})
 			} else {
 				console.error('Error processing new_transaction:', err)

--- a/src/currencyApi/currencies/common/methods/withdraw.ts
+++ b/src/currencyApi/currencies/common/methods/withdraw.ts
@@ -36,12 +36,12 @@ export function withdraw(this: Common) {
 			await tx.save()
 
 			if (txUpdate.status === 'confirmed') {
-				const user = await userApi.findUser.byId(tx.user)
+				const user = await userApi.findUser.byId(tx.userId)
 				await user.balanceOps.complete(this.name, tx._id)
 			}
 
 			callback(null, `${txUpdate.opid} updated`)
-			this.events.emit('update_sent_tx', tx.user, txUpdate)
+			this.events.emit('update_sent_tx', tx.userId, txUpdate)
 		} catch(err) {
 			if (err === 'OperationNotFound') {
 				callback({

--- a/src/currencyApi/index.ts
+++ b/src/currencyApi/index.ts
@@ -144,7 +144,7 @@ export async function withdraw(
 	// Adiciona a operação na Transactions
 	const transaction = await new Transaction({
 		_id: opid,
-		user: user.id,
+		userId: user.id,
 		type: 'send',
 		currency,
 		status: 'processing',

--- a/src/db/models/transaction.ts
+++ b/src/db/models/transaction.ts
@@ -1,7 +1,7 @@
 import { ObjectId, Decimal128 } from 'mongodb'
 import mongoose, { Schema, Document } from '../mongoose'
 import { detailsOf } from '../../currencyApi'
-import type { Person } from './person'
+import type User from '../../userApi/user'
 import type { SuportedCurrencies } from '../../currencyApi'
 
 /** Interface base de uma transaction */
@@ -144,7 +144,7 @@ export interface TxInfo {
 interface TransactionDoc extends Document {
 	_id: ObjectId
 	/** Referência ao usuário dono dessa transação */
-	user: Person['_id']
+	userId: User['id']
 	/**
 	 * Status da transação
 	 *
@@ -181,7 +181,7 @@ interface TransactionDoc extends Document {
 
 /** Schema da collection de transações dos usuários */
 const TransactionSchema: Schema = new Schema({
-	user: {
+	userId: {
 		type: ObjectId,
 		required: true,
 		ref: 'Person'

--- a/src/db/models/transaction.ts
+++ b/src/db/models/transaction.ts
@@ -1,5 +1,6 @@
 import { ObjectId, Decimal128 } from 'mongodb'
 import mongoose, { Schema, Document } from '../mongoose'
+import { detailsOf } from '../../currencyApi'
 import type { Person } from './person'
 import type { SuportedCurrencies } from '../../currencyApi'
 
@@ -210,6 +211,7 @@ const TransactionSchema: Schema = new Schema({
 		min: 0,
 		required: false
 	},
+	/** @todo Adicionar um validador de accounts */
 	account: {
 		type: String,
 		required: true
@@ -231,6 +233,10 @@ const TransactionSchema: Schema = new Schema({
 		type: Date,
 		required: true
 	}
+})
+
+TransactionSchema.pre('validate', function(this: TransactionDoc) {
+	this.amount = this.amount.truncate(detailsOf(this.currency).decimals)
 })
 
 /**

--- a/src/db/models/transaction.ts
+++ b/src/db/models/transaction.ts
@@ -236,7 +236,8 @@ const TransactionSchema: Schema = new Schema({
 })
 
 TransactionSchema.pre('validate', function(this: TransactionDoc) {
-	this.amount = this.amount.truncate(detailsOf(this.currency).decimals)
+	if (this.amount instanceof Decimal128)
+		this.amount = this.amount.truncate(detailsOf(this.currency).decimals)
 })
 
 /**

--- a/src/libs/decimal128.extension.ts
+++ b/src/libs/decimal128.extension.ts
@@ -14,6 +14,15 @@ declare module 'mongodb' {
 		 * absolute value of -5 is the same as the absolute value of 5
 		 */
 		abs(): Decimal128
+		/**
+		 * Returns the opposite of this Decimal128 (the equivalent of -1 * x). For
+		 * example, the opposite of 5 is -5, -12 is 12 and so on
+		 */
+		opposite(): Decimal128
+		/**
+		 * Returns a truncated version of this Decimal128's intance
+		 */
+		truncate(decimals: number): Decimal128
 	}
 	// Extends the mongodb.Decimal128 object
 	namespace Decimal128 {
@@ -94,6 +103,23 @@ Decimal128.prototype.toFullString = function decimal128ToString() {
  */
 Decimal128.prototype.abs = function abs() {
 	return Decimal128.fromString(this.toString().replace(/^-/, ''))
+}
+
+/**
+ * Retorna o valor oposto de um decimal128 sem alterar o valor original
+ */
+Decimal128.prototype.opposite = function opposite() {
+	const str = this.toString()
+	return str.charAt(0) === '-'
+		? Decimal128.fromString(str.replace(/^-/, ''))
+		: Decimal128.fromString(str.padStart(str.length + 1, '-'))
+}
+
+/**
+ * Retorna uma versão truncada desse decimal128 sem alterar o valor original
+ */
+Decimal128.prototype.truncate = function truncate(decimals) {
+	return Decimal128.fromNumeric(this.toFullString(), decimals)
 }
 
 /**

--- a/src/server/api/v1/user.ts
+++ b/src/server/api/v1/user.ts
@@ -66,7 +66,7 @@ router.get('/transactions/:opid', async (req, res) => {
 		const tx = await Transaction.findById(req.params.opid)
 		if (!tx) throw 'NotFound'
 		// Checa se o usuario da transação é o mesmo que esta logado
-		if (tx.user.toHexString() !== req.user?.id.toHexString()) throw 'NotAuthorized'
+		if (tx.userId.toHexString() !== req.user?.id.toHexString()) throw 'NotAuthorized'
 		// Formata o objeto da transação
 		res.send({
 			opid:          tx.id,
@@ -103,7 +103,7 @@ router.get('/transactions', async (req, res) => {
 	/** Filtro de transações por currency */
 	const currency = CurrencyApi.currencies.find(currency => currency === req.query.currency)
 	/** Filtro da query do mongo */
-	const query = currency ? { user: req.user?.id, currency } : { user: req.user?.id }
+	const query = currency ? { userId: req.user?.id, currency } : { userId: req.user?.id }
 	/**
 	 * As 10 mais recentes transações do usuário,
 	 * filtrado de acordo com a query e pulando de acordo com skip

--- a/src/websocket/globalListeners.ts
+++ b/src/websocket/globalListeners.ts
@@ -98,7 +98,7 @@ GlobalListeners.add('get_tx_info', async function(this: SocketIO.Socket,
 ) {
 	if (!this.user) return callback('NotLoggedIn')
 	const tx = await Transaction.findById(opid)
-	if (tx?.user.toHexString() !== this.user.id.toHexString()) return callback('NotAuthorized')
+	if (tx?.userId.toHexString() !== this.user.id.toHexString()) return callback('NotAuthorized')
 
 	callback(null, {
 		status:        tx.status,

--- a/tests/CurrencyApi/operations.test.ts
+++ b/tests/CurrencyApi/operations.test.ts
@@ -78,10 +78,12 @@ describe('Testing operations on the currencyApi', () => {
 				expect(_tx_amount + _fee).to.equal(_tst_amount)
 			})
 
-			it('Should return AmountOfRange', async () => {
-				const { fee } = await CurrencyApi.detailsOf(currency)
-				await expect(CurrencyApi.withdraw(user, currency, account, (fee * -0.01))).to.eventually.be
-					.rejectedWith(`Withdraw amount for ${currency} must be at least '${2 * fee}', but got ${fee * -0.01}`)
+			it('Should return AmountOfRange if amount is lower than 2*fee', async () => {
+				const { fee } = CurrencyApi.detailsOf(currency)
+				await expect(
+					CurrencyApi.withdraw(user, currency, account, (2 * fee - 0.01 * fee))
+				).to.eventually.be
+					.rejectedWith(`Withdraw amount for ${currency} must be at least '${2 * fee}', but got ${2 * fee - 0.01 * fee}`)
 			})
 		})
 	}

--- a/tests/CurrencyApi/receiving-requests.test.ts
+++ b/tests/CurrencyApi/receiving-requests.test.ts
@@ -234,7 +234,7 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 						client.emit('new_transaction', negativeAmount, (err: any, opid?: string) => {
 							Promise.resolve().then(() => {
 								expect(err).to.be.an('object')
-								expect(err.code).to.equals('BadRequest')
+								expect(err.code).to.equals('ValidationError')
 								expect(err.message).to.be.a('string')
 								expect(opid).to.be.undefined
 								return Person.findById(user.id)
@@ -269,14 +269,14 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					})
 				})
 
-				it('Should return BadRequest if amount is not numeric', done => {
+				it('Should return ValidationError if amount is not numeric', done => {
 					const invalidAmount = {
 						...transaction,
 						amount: '68.94p'
 					}
 					client.emit('new_transaction', invalidAmount, (err: any, opid?: string) => {
 						try {
-							expect(err.code).to.equals('BadRequest')
+							expect(err.code).to.equals('ValidationError')
 							expect(err.message).to.be.a('string')
 							expect(opid).to.be.undefined
 							done()

--- a/tests/CurrencyApi/receiving-requests.test.ts
+++ b/tests/CurrencyApi/receiving-requests.test.ts
@@ -77,9 +77,11 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 
 				Transaction.find({}, (err, txs_before) => {
 					client.emit('new_transaction', transaction, (err: any, response?: any) => {
-						expect(err).to.haveOwnProperty('code').that.equals('UserNotFound')
-						expect(response).to.be.undefined
-						Transaction.find({}, (err, transactions) => {
+						Promise.resolve().then(() => {
+							expect(err).to.haveOwnProperty('code').that.equals('UserNotFound')
+							expect(response).to.be.undefined
+							return Transaction.find({})
+						}).then(transactions => {
 							expect(transactions.length).to.equals(txs_before.length)
 							done()
 						})
@@ -97,9 +99,11 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 				}
 
 				client.emit('new_transaction', transaction, (err: any, opid?: string) => {
-					expect(err).to.be.null
-					expect(opid).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(err).to.be.null
+						expect(opid).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.userId.toHexString()).to.equals(user.id.toHexString())
 						expect(doc.txid).to.equals(transaction.txid)
 						expect(doc.status).to.equals(transaction.status)

--- a/tests/CurrencyApi/receiving-requests.test.ts
+++ b/tests/CurrencyApi/receiving-requests.test.ts
@@ -100,7 +100,7 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					expect(err).to.be.null
 					expect(opid).to.be.a('string')
 					Transaction.findById(opid).then(doc => {
-						expect(doc.user.toHexString()).to.equals(user.id.toHexString())
+						expect(doc.userId.toHexString()).to.equals(user.id.toHexString())
 						expect(doc.txid).to.equals(transaction.txid)
 						expect(doc.status).to.equals(transaction.status)
 						expect(doc.amount.toFullString()).to.equals(transaction.amount.toString())

--- a/tests/CurrencyApi/receiving-requests.test.ts
+++ b/tests/CurrencyApi/receiving-requests.test.ts
@@ -1,7 +1,7 @@
 import '../../src/libs'
 import io from 'socket.io-client'
 import { expect } from 'chai'
-import { Decimal128, ObjectId } from 'mongodb'
+import { Decimal128 } from 'mongodb'
 import Person from '../../src/db/models/person'
 import Checklist from '../../src/db/models/checklist'
 import Transaction, { TxSend, UpdtSent } from '../../src/db/models/transaction'
@@ -41,7 +41,7 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 			client = io(`http://127.0.0.1:${CURRENCY_API_PORT}/${currency}`)
 
 			// Responde eventos de create_account para evitar timeout
-			client.on('create_new_account', async (callback: (err: any, account: string) => void) => {
+			client.on('create_new_account', (callback: (err: any, account: string) => void) => {
 				account_counter++
 				callback(null, 'account-' + currency + account_counter)
 			})
@@ -77,7 +77,7 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 
 				Transaction.find({}, (err, txs_before) => {
 					client.emit('new_transaction', transaction, (err: any, response?: any) => {
-						expect(err).to.haveOwnProperty('code').equals('UserNotFound')
+						expect(err).to.haveOwnProperty('code').that.equals('UserNotFound')
 						expect(response).to.be.undefined
 						Transaction.find({}, (err, transactions) => {
 							expect(transactions.length).to.equals(txs_before.length)
@@ -118,15 +118,13 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					timestamp: 123456789
 				}
 
-				setImmediate(async () => {
-					client.emit('new_transaction', transaction, () => {
-						Person.findById(user.id, (err, doc) => {
-							expect(doc.currencies[currency].balance.available.toFullString())
-								.to.equals('0.0')
-							expect(doc.currencies[currency].balance.locked.toFullString())
-								.to.equals(transaction.amount.toString())
-							done()
-						})
+				client.emit('new_transaction', transaction, () => {
+					Person.findById(user.id, (err, doc) => {
+						expect(doc.currencies[currency].balance.available.toFullString())
+							.to.equals('0.0')
+						expect(doc.currencies[currency].balance.locked.toFullString())
+							.to.equals(transaction.amount.toString())
+						done()
 					})
 				})
 			})
@@ -140,13 +138,14 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					timestamp: 123456789
 				}
 
-				client.emit('new_transaction', transaction, async () => {
-					const doc = await Person.findById(user.id)
-					expect(doc.currencies[currency].balance.available.toFullString())
-						.to.equals(transaction.amount.toString())
-					expect(doc.currencies[currency].balance.locked.toFullString())
-						.to.equals('0.0')
-					done()
+				client.emit('new_transaction', transaction, () => {
+					Person.findById(user.id, (err, doc) => {
+						expect(doc.currencies[currency].balance.available.toFullString())
+							.to.equals(transaction.amount.toString())
+						expect(doc.currencies[currency].balance.locked.toFullString())
+							.to.equals('0.0')
+						done()
+					})
 				})
 			})
 
@@ -165,7 +164,7 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					expect(tx).to.be.an('object')
 					expect(tx.txid).to.equals(transaction.txid)
 					expect(tx.status).to.equals(transaction.status)
-					expect(tx.amount.toString()).to.equals(transaction.amount.toString())
+					expect(tx.amount).to.equals(transaction.amount)
 					expect(tx.currency).to.equals(currency)
 					expect(tx.account).to.equals(transaction.account)
 					expect(tx.timestamp).to.be.a('Date')
@@ -189,39 +188,21 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					expect(err).to.be.null
 					expect(opid).to.be.a('string')
 					client.emit('new_transaction', transaction, (err: any, _opid?: string) => {
-						expect(_opid).to.be.undefined
-						expect(err).to.be.an('object')
-						expect(err.code).to.equals('TransactionExists')
-						expect(err.transaction).to.be.an('object')
-						expect(err.transaction.opid).to.equals(opid)
-						expect(err.transaction.txid).to.equals(transaction.txid)
-						expect(err.transaction.status).to.equals(transaction.status)
-						expect(err.transaction.amount).to.equals(transaction.amount.toString())
-						expect(err.transaction.account).to.equals(transaction.account)
-						done()
+						try {
+							expect(_opid).to.be.undefined
+							expect(err).to.be.an('object')
+							expect(err.code).to.equals('TransactionExists')
+							expect(err.transaction).to.be.an('object')
+							expect(err.transaction.opid).to.equals(opid)
+							expect(err.transaction.txid).to.equals(transaction.txid)
+							expect(err.transaction.status).to.equals(transaction.status)
+							expect(err.transaction.amount).to.equals(transaction.amount.toString())
+							expect(err.transaction.account).to.equals(transaction.account)
+							done()
+						} catch (err) {
+							done(err)
+						}
 					})
-				})
-			})
-
-			it('Sould ignore digits after supported when saving the transaction', done => {
-				const transaction: TxReceived = {
-					txid,
-					status: 'pending',
-					amount: 1.23456789101112131415,
-					account: `${currency}-account`,
-					timestamp: 123456789
-				}
-
-				client.emit('new_transaction', transaction, (err: any, opid?: string) => {
-					Transaction.findById(opid).then(doc => {
-						expect(doc.amount.toFullString()).to.equals(
-							Decimal128.fromNumeric(
-								transaction.amount,
-								CurrencyApi.detailsOf(currency).decimals
-							).toFullString()
-						)
-						done()
-					}).catch(done)
 				})
 			})
 
@@ -239,37 +220,37 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 						...transaction,
 						amount: -49.37954
 					}
-
-					setImmediate(async () => {
-						const available = Decimal128.fromNumeric(50).toFullString()
-						const locked = Decimal128.fromNumeric(0).toFullString()
-						const txs_before = await Transaction.find({})
-
-						// Garante que o request não irá falhar por falta de saldo
-						await Person.findByIdAndUpdate(user.id, {
-							$set: {
-								[`currencies.${currency}.balance.available`]: Decimal128.fromString(available),
-								[`currencies.${currency}.balance.locked`]: Decimal128.fromString(locked)
-							}
+					const available = Decimal128.fromNumeric(50).toFullString()
+					const locked = Decimal128.fromNumeric(0).toFullString()
+					// Garante que o request não irá falhar por falta de saldo
+					Person.findByIdAndUpdate(user.id, {
+						$set: {
+							[`currencies.${currency}.balance.available`]: Decimal128.fromString(available),
+							[`currencies.${currency}.balance.locked`]: Decimal128.fromString(locked)
+						}
+					}).then(() => {
+						return Transaction.find({})
+					}).then(txs_before => {
+						client.emit('new_transaction', negativeAmount, (err: any, opid?: string) => {
+							Promise.resolve().then(() => {
+								expect(err).to.be.an('object')
+								expect(err.code).to.equals('BadRequest')
+								expect(err.message).to.be.a('string')
+								expect(opid).to.be.undefined
+								return Person.findById(user.id)
+							}).then(doc => {
+								// Checa se o doc do usuário não foi alterado
+								expect(doc.currencies[currency].balance.available.toFullString())
+									.to.equals(available)
+								expect(doc.currencies[currency].balance.locked.toFullString())
+									.to.equals(locked)
+								return Transaction.find({})
+							}).then(txs => {
+								expect(txs).to.have.lengthOf(txs_before.length)
+								done()
+							}).catch(done)
 						})
-
-						client.emit('new_transaction', negativeAmount, async (err: any, opid?: string) => {
-							expect(err).to.be.an('object')
-							expect(err.code).to.equals('BadRequest')
-							expect(err.message).to.be.a('string')
-							expect(opid).to.be.undefined
-
-							const doc = await Person.findById(user.id)
-							expect(doc.currencies[currency].balance.available.toFullString())
-								.to.equals(available)
-							expect(doc.currencies[currency].balance.locked.toFullString())
-								.to.equals(locked)
-
-							const txs = await Transaction.find({})
-							expect(txs).to.have.lengthOf(txs_before.length)
-							done()
-						})
-					})
+					}).catch(done)
 				})
 
 				it('Should return ValidationError if status is invalid', done => {
@@ -278,9 +259,13 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 						status: 'not-valid-status'
 					}
 					client.emit('new_transaction', invalidStatus, (err: any, opid?: string) => {
-						expect(err.code).to.equals('ValidationError')
-						expect(opid).to.be.undefined
-						done()
+						try {
+							expect(err.code).to.equals('ValidationError')
+							expect(opid).to.be.undefined
+							done()
+						} catch (err) {
+							done(err)
+						}
 					})
 				})
 
@@ -290,10 +275,14 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 						amount: '68.94p'
 					}
 					client.emit('new_transaction', invalidAmount, (err: any, opid?: string) => {
-						expect(err.code).to.equals('BadRequest')
-						expect(err.message).to.be.a('string')
-						expect(opid).to.be.undefined
-						done()
+						try {
+							expect(err.code).to.equals('BadRequest')
+							expect(err.message).to.be.a('string')
+							expect(opid).to.be.undefined
+							done()
+						} catch (err) {
+							done(err)
+						}
 					})
 				})
 
@@ -303,9 +292,13 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 						confirmations: '6j'
 					}
 					client.emit('new_transaction', invalidConfirmations, (err: any, opid?: string) => {
-						expect(err.code).to.equals('ValidationError')
-						expect(opid).to.be.undefined
-						done()
+						try {
+							expect(err.code).to.equals('ValidationError')
+							expect(opid).to.be.undefined
+							done()
+						} catch (err) {
+							done(err)
+						}
 					})
 				})
 
@@ -315,9 +308,13 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 						timestamp: '123456789t'
 					}
 					client.emit('new_transaction', invalidTimestamp, (err: any, opid?: string) => {
-						expect(err.code).to.equals('ValidationError')
-						expect(opid).to.be.undefined
-						done()
+						try {
+							expect(err.code).to.equals('ValidationError')
+							expect(opid).to.be.undefined
+							done()
+						} catch (err) {
+							done(err)
+						}
 					})
 				})
 			})
@@ -342,10 +339,14 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 						timestamp: 123456789
 					}
 					client.emit('new_transaction', transaction, (err: any, _opid?: string) => {
-						expect(err).to.be.null
-						expect(_opid).to.be.a('string')
-						opid = _opid
-						done()
+						try {
+							expect(err).to.be.null
+							expect(_opid).to.be.a('string')
+							opid = _opid
+							done()
+						} catch (err) {
+							done(err)
+						}
 					})
 				}).catch(done)
 			})
@@ -357,14 +358,16 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					confirmations: 6
 				}
 
-				client.emit('update_received_tx', updReceived, async (err: any, res?: string) => {
-					expect(err).to.be.null
-					expect(res).to.be.a('string')
-
-					const doc = await Transaction.findById(opid)
-					expect(doc.status).to.equals(updReceived.status)
-					expect(doc.confirmations).to.equals(updReceived.confirmations)
-					done()
+				client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
+					Promise.resolve().then(() => {
+						expect(err).to.be.null
+						expect(res).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
+						expect(doc.status).to.equals(updReceived.status)
+						expect(doc.confirmations).to.equals(updReceived.confirmations)
+						done()
+					}).catch(done)
 				})
 			})
 
@@ -375,27 +378,28 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					confirmations: 6
 				}
 
-				client.emit('update_received_tx', updReceived, async (err: any, res?: string) => {
-					expect(err).to.be.null
-					expect(res).to.be.a('string')
-
-					const doc = await Transaction.findById(opid)
-					expect(doc.status).to.equals(updReceived.status)
-					expect(doc.confirmations).to.be.undefined
-					done()
+				client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
+					Promise.resolve().then(() => {
+						expect(err).to.be.null
+						expect(res).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
+						expect(doc.status).to.equals(updReceived.status)
+						expect(doc.confirmations).to.be.undefined
+						done()
+					}).catch(done)
 				})
 			})
 
 			it('Should return UserNotFound if a user for existing transaction was not found', done => {
-				setImmediate(async () => {
-					// Configura o novo usuário
-					const newUser = await UserApi.createUser(`UserNotFound-receive-${currency}@email.com`, 'UserP@ass')
-					await Person.findByIdAndUpdate(newUser.id, {
+				// Configura o novo usuário
+				UserApi.createUser(`UserNotFound-receive-${currency}@email.com`, 'UserP@ass').then(newUser => {
+					return Person.findByIdAndUpdate(newUser.id, {
 						$push: {
 							[`currencies.${currency}.accounts`]: `${currency}-account-newUser`
 						}
 					})
-
+				}).then(person => {
 					// Emite a transação
 					client.emit('new_transaction', {
 						txid: `UserNotFound-txid-${currency}`,
@@ -404,26 +408,31 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 						account: `${currency}-account-newUser`,
 						timestamp: 123456789
 					}, (err: any, opid?: string) => {
-						expect(err).to.be.null
-						expect(opid).to.be.a('string')
-
-						// Deleta o novo usuário
-						Person.findByIdAndDelete(newUser.id).then(() => {
+						Promise.resolve().then(() => {
+							expect(err).to.be.null
+							expect(opid).to.be.a('string')
+							// Deleta o novo usuário
+							return Person.findByIdAndDelete(person.id)
+						}).then(() => {
 							// Envia um update para a transação do usuário deletado
 							client.emit('update_received_tx', {
 								opid,
 								status: 'confirmed',
 								confirmations: 6
 							}, (err: any, res?: string) => {
-								expect(res).to.be.undefined
-								expect(err).to.be.an('object')
-								expect(err.code).to.equals('UserNotFound')
-								expect(err.message).to.be.a('string')
-								done()
+								try {
+									expect(res).to.be.undefined
+									expect(err).to.be.an('object')
+									expect(err.code).to.equals('UserNotFound')
+									expect(err.message).to.be.a('string')
+									done()
+								} catch (err) {
+									done(err)
+								}
 							})
 						}).catch(done)
 					})
-				})
+				}).catch(done)
 			})
 
 			it('Sould not update balance if status is pending', done => {
@@ -434,9 +443,11 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 				}
 
 				client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
-					expect(err).to.be.null
-					expect(res).to.be.a('string')
-					Person.findById(user.id).then(doc => {
+					Promise.resolve().then(() => {
+						expect(err).to.be.null
+						expect(res).to.be.a('string')
+						return Person.findById(user.id)
+					}).then(doc => {
 						expect(doc.currencies[currency].balance.locked.toFullString())
 							.to.equals(txAmount)
 						expect(doc.currencies[currency].balance.available.toFullString())
@@ -454,9 +465,11 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 				}
 
 				client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
-					expect(err).to.be.null
-					expect(res).to.be.a('string')
-					Person.findById(user.id).then(doc => {
+					Promise.resolve().then(() => {
+						expect(err).to.be.null
+						expect(res).to.be.a('string')
+						return Person.findById(user.id)
+					}).then(doc => {
 						expect(doc.currencies[currency].balance.locked.toFullString())
 							.to.equals('0.0')
 						expect(doc.currencies[currency].balance.available.toFullString())
@@ -473,13 +486,15 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 				}
 
 				client.emit('update_received_tx', updReceived, (err: any, res?: string) => {
-					expect(err).to.be.null
-					expect(res).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(err).to.be.null
+						expect(res).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.status).to.equals(updReceived.status)
 						expect(doc.confirmations).to.be.undefined
 						done()
-					})
+					}).catch(done)
 				})
 			})
 
@@ -488,12 +503,14 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					status: 'confirmed',
 					confirmations: 6
 				}, (err: any, res?: string) => {
-					expect(res).to.be.undefined
-					expect(err).to.be.a('object')
-					expect(err.code).to.be.a('string')
-						.that.equals('BadRequest')
-					expect(err.message).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(res).to.be.undefined
+						expect(err).to.be.a('object')
+						expect(err.code).to.be.a('string')
+							.that.equals('BadRequest')
+						expect(err.message).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.status).to.equals('pending')
 						done()
 					}).catch(done)
@@ -506,12 +523,14 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					status: 'confirmed',
 					confirmations: 6
 				}, (err: any, res?: string) => {
-					expect(res).to.be.undefined
-					expect(err).to.be.a('object')
-					expect(err.code).to.be.a('string')
-						.that.equals('OperationNotFound')
-					expect(err.message).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(res).to.be.undefined
+						expect(err).to.be.a('object')
+						expect(err.code).to.be.a('string')
+							.that.equals('OperationNotFound')
+						expect(err.message).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.status).to.equals('pending')
 						done()
 					}).catch(done)
@@ -524,12 +543,14 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					status: 'confirmed',
 					confirmations: 6
 				}, (err: any, res?: string) => {
-					expect(res).to.be.undefined
-					expect(err).to.be.a('object')
-					expect(err.code).to.be.a('string')
-						.that.equals('CastError')
-					expect(err.message).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(res).to.be.undefined
+						expect(err).to.be.a('object')
+						expect(err.code).to.be.a('string')
+							.that.equals('CastError')
+						expect(err.message).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.status).to.equals('pending')
 						done()
 					}).catch(done)
@@ -542,12 +563,14 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					status: 'invalid-status',
 					confirmations: 6
 				}, (err: any, res?: string) => {
-					expect(res).to.be.undefined
-					expect(err).to.be.a('object')
-					expect(err.code).to.be.a('string')
-						.that.equals('ValidationError')
-					expect(err.message).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(res).to.be.undefined
+						expect(err).to.be.a('object')
+						expect(err.code).to.be.a('string')
+							.that.equals('ValidationError')
+						expect(err.message).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.status).to.equals('pending')
 						done()
 					}).catch(done)
@@ -590,9 +613,11 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 				}
 
 				client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
-					expect(err).to.be.null
-					expect(res).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(err).to.be.null
+						expect(res).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.txid).to.equals(updSent.txid)
 						expect(doc.status).to.equals(updSent.status)
 						expect(doc.confirmations).to.equals(updSent.confirmations)
@@ -612,9 +637,11 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 				}
 
 				client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
-					expect(err).to.be.null
-					expect(res).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(err).to.be.null
+						expect(res).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.txid).to.equals(updSent.txid)
 						expect(doc.status).to.equals(updSent.status)
 						expect(doc.confirmations).to.be.undefined
@@ -625,39 +652,49 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 			})
 
 			it('Should return UserNotFound if a user for existing transaction was not found', done => {
-				let _user: User
-				let _opid: ObjectId
+				let user: User
 
-				client.once('withdraw', (request: TxSend, callback: (err: any, response?: string) => void) => {
-					callback(null, 'received withdraw request for userNotFound test')
-
-					Person.findByIdAndDelete(_user.id).then(() => {
-						client.emit('update_sent_tx', {
-							opid: _opid,
-							txid: `randomTxId-deleted-user-${currency}`,
-							status: 'confirmed',
-							confirmations: 6,
-							timestamp: 123456789
-						}, (err: any, res?: string) => {
-							expect(res).to.be.undefined
-							expect(err).to.be.an('object')
-							expect(err.code).to.equals('UserNotFound')
-							expect(err.message).to.be.a('string')
-							done()
-						})
-					}).catch(done)
-				})
-
-				setImmediate(async () => {
-					_user = await UserApi.createUser(`non-existing-user-send-${currency}@email.com`, 'UserP@ass')
-					await Person.findByIdAndUpdate(_user.id, {
+				// Cria o usuário
+				UserApi.createUser(`non-existing-user-send-${currency}@email.com`, 'UserP@ass').then(_user => {
+					user = _user
+					// Seta o saldo do usuário
+					return Person.findByIdAndUpdate(_user.id, {
 						$set: {
 							[`currencies.${currency}.balance.available`]: Decimal128.fromNumeric(50),
 							[`currencies.${currency}.balance.locked`]: Decimal128.fromNumeric(0)
 						}
 					})
-					_opid = await CurrencyApi.withdraw(_user, currency, 'randomAccount', 10)
-				})
+				}).then(() => {
+					// Executa o saque
+					return CurrencyApi.withdraw(user, currency, 'randomAccount', 10)
+				}).then(opid => {
+					// Recebe o request de saque
+					client.once('withdraw', (request: TxSend, callback: (err: any, response?: string) => void) => {
+						callback(null, 'received withdraw request for userNotFound test')
+
+						// Deleta o usuário
+						Person.findByIdAndDelete(user.id).then(() => {
+							// Emite o update para o usuário deletado
+							client.emit('update_sent_tx', {
+								opid,
+								txid: `randomTxId-deleted-user-${currency}`,
+								status: 'confirmed',
+								confirmations: 6,
+								timestamp: 123456789
+							}, (err: any, res?: string) => {
+								try {
+									expect(res).to.be.undefined
+									expect(err).to.be.an('object')
+									expect(err.code).to.equals('UserNotFound')
+									expect(err.message).to.be.a('string')
+									done()
+								} catch (err) {
+									done(err)
+								}
+							})
+						}).catch(done)
+					})
+				}).catch(done)
 			})
 
 			it('Sould not update balance if status is pending', done => {
@@ -670,9 +707,11 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 				}
 
 				client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
-					expect(err).to.be.null
-					expect(res).to.be.a('string')
-					Person.findById(user.id).then(doc => {
+					Promise.resolve().then(() => {
+						expect(err).to.be.null
+						expect(res).to.be.a('string')
+						return Person.findById(user.id)
+					}).then(doc => {
 						expect(doc.currencies[currency].balance.locked.toFullString())
 							.to.equals('10.0')
 						expect(doc.currencies[currency].balance.available.toFullString())
@@ -692,9 +731,11 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 				}
 
 				client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
-					expect(err).to.be.null
-					expect(res).to.be.a('string')
-					Person.findById(user.id).then(doc => {
+					Promise.resolve().then(() => {
+						expect(err).to.be.null
+						expect(res).to.be.a('string')
+						return Person.findById(user.id)
+					}).then(doc => {
 						expect(doc.currencies[currency].balance.locked.toFullString())
 							.to.equals('0.0')
 						expect(doc.currencies[currency].balance.available.toFullString())
@@ -713,9 +754,11 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 				}
 
 				client.emit('update_sent_tx', updSent, (err: any, res?: string) => {
-					expect(err).to.be.null
-					expect(res).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(err).to.be.null
+						expect(res).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.status).to.equals(updSent.status)
 						expect(doc.confirmations).to.be.undefined
 						done()
@@ -730,12 +773,14 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					confirmations: 6,
 					timestamp: 123456789
 				}, (err: any, res?: string) => {
-					expect(res).to.be.undefined
-					expect(err).to.be.a('object')
-					expect(err.code).to.be.a('string')
-						.that.equals('BadRequest')
-					expect(err.message).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(res).to.be.undefined
+						expect(err).to.be.a('object')
+						expect(err.code).to.be.a('string')
+							.that.equals('BadRequest')
+						expect(err.message).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.status).to.equals('processing')
 						done()
 					}).catch(done)
@@ -750,12 +795,14 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					confirmations: 6,
 					timestamp: 123456789
 				}, (err: any, res?: string) => {
-					expect(res).to.be.undefined
-					expect(err).to.be.a('object')
-					expect(err.code).to.be.a('string')
-						.that.equals('OperationNotFound')
-					expect(err.message).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(res).to.be.undefined
+						expect(err).to.be.a('object')
+						expect(err.code).to.be.a('string')
+							.that.equals('OperationNotFound')
+						expect(err.message).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.status).to.equals('processing')
 						done()
 					}).catch(done)
@@ -770,12 +817,14 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					confirmations: 6,
 					timestamp: 123456789
 				}, (err: any, res?: string) => {
-					expect(res).to.be.undefined
-					expect(err).to.be.a('object')
-					expect(err.code).to.be.a('string')
-						.that.equals('CastError')
-					expect(err.message).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(res).to.be.undefined
+						expect(err).to.be.a('object')
+						expect(err.code).to.be.a('string')
+							.that.equals('CastError')
+						expect(err.message).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.status).to.equals('processing')
 						done()
 					}).catch(done)
@@ -790,12 +839,14 @@ describe('Testing the receival of events on the CurrencyApi', () => {
 					confirmations: 6,
 					timestamp: 123456789
 				}, (err: any, res?: string) => {
-					expect(res).to.be.undefined
-					expect(err).to.be.a('object')
-					expect(err.code).to.be.a('string')
-						.that.equals('ValidationError')
-					expect(err.message).to.be.a('string')
-					Transaction.findById(opid).then(doc => {
+					Promise.resolve().then(() => {
+						expect(res).to.be.undefined
+						expect(err).to.be.a('object')
+						expect(err.code).to.be.a('string')
+							.that.equals('ValidationError')
+						expect(err.message).to.be.a('string')
+						return Transaction.findById(opid)
+					}).then(doc => {
 						expect(doc.status).to.equals('processing')
 						done()
 					}).catch(done)

--- a/tests/CurrencyApi/sending-requests.test.ts
+++ b/tests/CurrencyApi/sending-requests.test.ts
@@ -44,7 +44,7 @@ describe('Testing if CurrencyApi is making requests to the websocket', () => {
 						callback(null, `account-${currency}`)
 						done()
 					})
-				})
+				}).catch(done)
 			})
 
 			it('Should receive a withdraw request', done => {
@@ -72,7 +72,7 @@ describe('Testing if CurrencyApi is making requests to the websocket', () => {
 						callback(null, 'request received for' + currency)
 						done()
 					})
-				})
+				}).catch(done)
 			})
 		})
 
@@ -93,9 +93,7 @@ describe('Testing if CurrencyApi is making requests to the websocket', () => {
 					done()
 				})
 
-				CurrencyApi.create_accounts(user.id, [currency]).catch(err => {
-					done(err)
-				})
+				CurrencyApi.create_accounts(user.id, [currency]).catch(done)
 			})
 
 			it('Should receive a withdraw request immediate after requested', done => {
@@ -105,8 +103,8 @@ describe('Testing if CurrencyApi is making requests to the websocket', () => {
 					callback: (err: any, response?: string) => void
 				) => {
 					expect(request).to.be.an('object')
-
 					expect(request.opid).to.be.a('string')
+
 					const tx = await Transaction.findById(request.opid)
 					expect(tx).to.be.an('object')
 
@@ -121,7 +119,7 @@ describe('Testing if CurrencyApi is making requests to the websocket', () => {
 				})
 
 				CurrencyApi.withdraw(user, currency, `${currency}_account`, amount)
-					.catch(err => done(err))
+					.catch(done)
 			})
 		})
 	}

--- a/tests/CurrencyApi/sending-requests.test.ts
+++ b/tests/CurrencyApi/sending-requests.test.ts
@@ -56,21 +56,25 @@ describe('Testing if CurrencyApi is making requests to the websocket', () => {
 						request: TxSend,
 						callback: (err: any, response?: string) => void
 					) => {
-						expect(request).to.be.an('object')
+						try {
+							expect(request).to.be.an('object')
 
-						expect(request.opid).to.be.a('string')
-							.that.equals(opid.toHexString())
+							expect(request.opid).to.be.a('string')
+								.that.equals(opid.toHexString())
 
-						const tx = await Transaction.findById(opid)
+							const tx = await Transaction.findById(opid)
 
-						expect(request.account).to.be.a('string')
-							.that.equals(tx.account)
+							expect(request.account).to.be.a('string')
+								.that.equals(tx.account)
 
-						expect(request.amount).to.be.a('string')
-							.that.equals(tx.amount.toFullString())
+							expect(request.amount).to.be.a('string')
+								.that.equals(tx.amount.toFullString())
 
+							done()
+						} catch (err) {
+							done(err)
+						}
 						callback(null, 'request received for' + currency)
-						done()
 					})
 				}).catch(done)
 			})
@@ -102,20 +106,24 @@ describe('Testing if CurrencyApi is making requests to the websocket', () => {
 					request: TxSend,
 					callback: (err: any, response?: string) => void
 				) => {
-					expect(request).to.be.an('object')
-					expect(request.opid).to.be.a('string')
+					try {
+						expect(request).to.be.an('object')
+						expect(request.opid).to.be.a('string')
 
-					const tx = await Transaction.findById(request.opid)
-					expect(tx).to.be.an('object')
+						const tx = await Transaction.findById(request.opid)
+						expect(tx).to.be.an('object')
 
-					expect(request.account).to.be.a('string')
-						.that.equals(tx.account)
+						expect(request.account).to.be.a('string')
+							.that.equals(tx.account)
 
-					expect(request.amount).to.be.a('string')
-						.that.equals(tx.amount.toFullString())
+						expect(request.amount).to.be.a('string')
+							.that.equals(tx.amount.toFullString())
 
+						done()
+					} catch (err) {
+						done(err)
+					}
 					callback(null, 'request received for' + currency)
-					done()
 				})
 
 				CurrencyApi.withdraw(user, currency, `${currency}_account`, amount)

--- a/tests/httpApi/v1.test.ts
+++ b/tests/httpApi/v1.test.ts
@@ -257,7 +257,7 @@ describe('Testing version 1 of HTTP API', () => {
 					expect(body).to.be.an('array')
 					expect(body.length).to.be.lte(10)
 					transactions.forEach(tx_stored => {
-						const tx_received = body.find(e => e.opid === tx_stored._id.toHexString())
+						const tx_received = body.find(e => e.opid === tx_stored.id)
 						expect(tx_received).to.be.an('object', `Transaction with opid ${tx_stored._id} not sent`)
 						expect(Object.entries(tx_received).length).to.equal(9)
 						expect(tx_received.opid).to.equals(tx_stored._id.toHexString())

--- a/tests/libs/decimal128.test.ts
+++ b/tests/libs/decimal128.test.ts
@@ -73,4 +73,17 @@ describe('Testing decimal128\'s extension library', () => {
 		expect(() => Decimal128.fromNumeric('235 78')).to.throw()
 		expect(() => Decimal128.fromNumeric('abacaxi')).to.throw()
 	})
+
+	it('Should truncate decimals beyond specified', () => {
+		expect(Decimal128.fromNumeric(2).truncate(0).toFullString()).to.equals('2.0')
+		expect(Decimal128.fromNumeric(-2).truncate(0).toFullString()).to.equals('-2.0')
+		expect(Decimal128.fromNumeric(2e-2).truncate(1).toFullString()).to.equals('0.0')
+		expect(Decimal128.fromNumeric(0.000000001).truncate(8).toFullString()).to.equals('0.0')
+		expect(Decimal128.fromNumeric(51687314e-5).truncate(3).toFullString()).to.equals('516.873')
+		expect(Decimal128.fromNumeric(-51687314e-5).truncate(1).toFullString()).to.equals('-516.8')
+		expect(Decimal128.fromNumeric(4.21657893e4).truncate(6).toFullString()).to.equals('42165.7893')
+		expect(Decimal128.fromNumeric(15664.21657893e-4).truncate(4).toFullString()).to.equals('1.5664')
+		expect(Decimal128.fromNumeric(15664.21657893e-4).truncate(0).toFullString()).to.equals('1.566421657893')
+		expect(Decimal128.fromNumeric(14E10).truncate(0).toFullString()).to.equals('140000000000.0')
+	})
 })

--- a/tests/mongodb/transactions.test.ts
+++ b/tests/mongodb/transactions.test.ts
@@ -6,7 +6,7 @@ import Transaction from '../../src/db/models/transaction'
 describe('Testing transactions collection', () => {
 	it('Should fail to save a transaction with negative amount', async () => {
 		const tx = new Transaction({
-			user: new ObjectId(),
+			userId: new ObjectId(),
 			txid: 'random-txid',
 			type: 'receive',
 			currency: 'bitcoin',
@@ -23,7 +23,7 @@ describe('Testing transactions collection', () => {
 
 	it('Should truncate the amount of the amount after the supported for that currency', async () => {
 		const tx = new Transaction({
-			user: new ObjectId(),
+			userId: new ObjectId(),
 			txid: 'random-txid',
 			type: 'receive',
 			currency: 'bitcoin',
@@ -38,7 +38,7 @@ describe('Testing transactions collection', () => {
 
 	it('Should save a transaction', async () => {
 		const tx = new Transaction({
-			user: new ObjectId(),
+			userId: new ObjectId(),
 			txid: 'random-txid',
 			type: 'receive',
 			currency: 'bitcoin',

--- a/tests/mongodb/transactions.test.ts
+++ b/tests/mongodb/transactions.test.ts
@@ -1,0 +1,52 @@
+import '../../src/libs'
+import { expect } from 'chai'
+import { ObjectId } from 'mongodb'
+import Transaction from '../../src/db/models/transaction'
+
+describe('Testing transactions collection', () => {
+	it('Should fail to save a transaction with negative amount', async () => {
+		const tx = new Transaction({
+			user: new ObjectId(),
+			txid: 'random-txid',
+			type: 'receive',
+			currency: 'bitcoin',
+			status: 'processing',
+			account: 'random-account',
+			amount: -1,
+			timestamp: new Date()
+		})
+		await expect(tx.save()).to.eventually.be
+			.rejectedWith('-1.0 must be a positive number')
+	})
+
+	it('Should fail to save a transaction with invalid account')
+
+	it('Should truncate the amount of the amount after the supported for that currency', async () => {
+		const tx = new Transaction({
+			user: new ObjectId(),
+			txid: 'random-txid',
+			type: 'receive',
+			currency: 'bitcoin',
+			status: 'processing',
+			account: 'random-account',
+			amount: 1.12345678910,
+			timestamp: new Date()
+		})
+		await tx.validate()
+		expect(tx.amount.toFullString()).to.equals('1.12345678')
+	})
+
+	it('Should save a transaction', async () => {
+		const tx = new Transaction({
+			user: new ObjectId(),
+			txid: 'random-txid',
+			type: 'receive',
+			currency: 'bitcoin',
+			status: 'processing',
+			account: 'random-account',
+			amount: 1.12345678910,
+			timestamp: new Date()
+		})
+		await expect(tx.save()).to.eventually.be.fulfilled
+	})
+})


### PR DESCRIPTION
-- Refatorado os testes da CurrencyApi e corrigido bugs nas assertions
-- Adicionado testes da collection de transactions
-- Adicionado um método 'truncate' ao prototype do Decimal128, que corta os decimais extra de uma instância de um Decimal128 e o retorna (o mesmo usado pelo fromNumeric)
-- Adicionado pre hook na collection de transactions para fazer a truncagem do amount da transação
-- Removido testes de funções da CurrencyApi que foram movidas para o mongoose
-- Renomeado a propriedade user da collection transactions para userId